### PR TITLE
Sdl window resizing

### DIFF
--- a/spyvm/primitives.py
+++ b/spyvm/primitives.py
@@ -787,6 +787,14 @@ def func(interp, s_frame, w_rcvr):
     # TODO: figure out whether we should decide the width an report it in the SCREEN_SIZE primitive
     form = wrapper.FormWrapper(interp.space, w_rcvr)
     form.take_over_display()
+    if interp.space.display().width == 0:
+        if not interp.image:
+            raise PrimitiveFailedError
+        display = interp.space.display()
+        width = (interp.image.lastWindowSize >> 16) & 0xffff
+        height = interp.image.lastWindowSize & 0xffff
+        print "hack",
+        display.set_video_mode(width, height, display.depth)
     w_display_bitmap = form.get_display_bitmap()
     w_display_bitmap.take_over_display()
     w_display_bitmap.flush_to_screen()

--- a/spyvm/primitives.py
+++ b/spyvm/primitives.py
@@ -784,7 +784,6 @@ def func(interp, s_frame, w_rcvr):
         old_display.relinquish_display()
     interp.space.objtable['w_display'] = w_rcvr
 
-    # TODO: figure out whether we should decide the width an report it in the SCREEN_SIZE primitive
     form = wrapper.FormWrapper(interp.space, w_rcvr)
     form.take_over_display()
     if interp.space.display().width == 0:
@@ -793,7 +792,6 @@ def func(interp, s_frame, w_rcvr):
         display = interp.space.display()
         width = (interp.image.lastWindowSize >> 16) & 0xffff
         height = interp.image.lastWindowSize & 0xffff
-        print "hack",
         display.set_video_mode(width, height, display.depth)
     w_display_bitmap = form.get_display_bitmap()
     w_display_bitmap.take_over_display()

--- a/spyvm/primitives.py
+++ b/spyvm/primitives.py
@@ -824,14 +824,10 @@ def func(interp, s_frame, w_rcvr):
 
 @expose_primitive(SCREEN_SIZE, unwrap_spec=[object])
 def func(interp, s_frame, w_rcvr):
-    # We need to have the indirection via interp.image, because when the image
-    # is saved, the display form size is always reduced to 240@120.
-    if not interp.image:
-        raise PrimitiveFailedError
     w_res = interp.space.w_Point.as_class_get_shadow(interp.space).new(2)
     point = wrapper.PointWrapper(interp.space, w_res)
-    point.store_x((interp.image.lastWindowSize >> 16) & 0xffff)
-    point.store_y(interp.image.lastWindowSize & 0xffff)
+    point.store_x(interp.space.display().width)
+    point.store_y(interp.space.display().height)
     return w_res
 
 @expose_primitive(MOUSE_BUTTONS, unwrap_spec=[object])

--- a/spyvm/test/test_primitives.py
+++ b/spyvm/test/test_primitives.py
@@ -762,6 +762,24 @@ def test_primitive_force_display_update(monkeypatch):
     finally:
         monkeypatch.undo()
 
+def test_screen_size_queries_sdl_window_size(monkeypatch):
+    class MockDisplay:
+        width = 3
+        height = 2
+    mock_display = MockDisplay()
+    monkeypatch.setattr(space, 'display', lambda: mock_display)
+    mock_displayScreen_class = bootstrap_class(0)
+    def assert_screen_size():
+        w_screen_size = prim(primitives.SCREEN_SIZE, [mock_displayScreen_class])
+        assert w_screen_size.getclass(space) is space.w_Point
+        screen_size_point = wrapper.PointWrapper(space, w_screen_size)
+        assert screen_size_point.x() == mock_display.width
+        assert screen_size_point.y() == mock_display.height
+    assert_screen_size()
+    mock_display.width = 4
+    mock_display.height = 3
+    assert_screen_size()
+
 # Note:
 #   primitives.NEXT is unimplemented as it is a performance optimization
 #   primitives.NEXT_PUT is unimplemented as it is a performance optimization


### PR DESCRIPTION
fixes #25

...but it is not really fast, I have to wait several seconds until the screen is redrawn. Basically, approx. as long as the first frame after starting the VM takes.

It seems like the 4.6 trunk image is polling for resizes via DisplayScreen class >> checkForNewScreenSize and not with any windowing events which could be handed out of the getNextEvent primitive.

Also there are three calls to SDLDisplay.set_video_mode per SDL resize event. One from the event handler in SDLDisplay and two following from FormWrapper.take_over_display, probably coming somewhere from the polling in #checkForNewScreenSize and the subsequent repeated #startUp of the DisplayScreen class.
