### PR TITLE
implemented primitiveCreateDirectory, primitiveDeleteDirectory and primitiveDeleteFile

### DIFF
--- a/spyvm/plugins/fileplugin.py
+++ b/spyvm/plugins/fileplugin.py
@@ -17,9 +17,21 @@ try:
 except ValueError:
     std_fds = [0, 1, 2]
 
+#primitiveDirectoryEntry ?
+#primitiveHasFileAccess ?
+#primitiveFileDelete
+
 @FilePlugin.expose_primitive(unwrap_spec=[object])
 def primitiveDirectoryDelimitor(interp, s_frame, w_rcvr):
     return interp.space.wrap_char(os.path.sep)
+
+@FilePlugin.expose_primitive(unwrap_spec=[object, str])
+def primitiveDirectoryCreate(interp, s_frame, w_rcvr, dir_path):
+    try:
+        os.mkdir(dir_path, 0777)
+    except OSError:
+        raise PrimitiveFailedError
+    return w_rcvr
 
 @FilePlugin.expose_primitive(unwrap_spec=[object, str, index1_0])
 def primitiveDirectoryLookup(interp, s_frame, w_file_directory, full_path, index):

--- a/spyvm/plugins/fileplugin.py
+++ b/spyvm/plugins/fileplugin.py
@@ -33,6 +33,15 @@ def primitiveDirectoryCreate(interp, s_frame, w_rcvr, dir_path):
         raise PrimitiveFailedError
     return w_rcvr
 
+
+@FilePlugin.expose_primitive(unwrap_spec=[object, str])
+def primitiveDirectoryDelete(interp, s_frame, w_rcvr, dir_path):
+    try:
+        os.rmdir(dir_path)
+    except OSError:
+        raise PrimitiveFailedError
+    return w_rcvr
+
 @FilePlugin.expose_primitive(unwrap_spec=[object, str, index1_0])
 def primitiveDirectoryLookup(interp, s_frame, w_file_directory, full_path, index):
     if full_path == '':

--- a/spyvm/plugins/fileplugin.py
+++ b/spyvm/plugins/fileplugin.py
@@ -17,9 +17,17 @@ try:
 except ValueError:
     std_fds = [0, 1, 2]
 
-#primitiveDirectoryEntry ?
-#primitiveHasFileAccess ?
-#primitiveFileDelete
+#should we implement primitiveDirectoryEntry ?
+#should we implement primitiveHasFileAccess ?
+
+@FilePlugin.expose_primitive(unwrap_spec=[object, str])
+def primitiveFileDelete(interp, s_frame, w_rcvr, file_path):
+    # we actually should ask the security plugin function sCDFfn for permissions
+    try:
+        os.remove(file_path)
+    except OSError:
+        raise PrimitiveFailedError
+    return w_rcvr
 
 @FilePlugin.expose_primitive(unwrap_spec=[object])
 def primitiveDirectoryDelimitor(interp, s_frame, w_rcvr):
@@ -27,15 +35,16 @@ def primitiveDirectoryDelimitor(interp, s_frame, w_rcvr):
 
 @FilePlugin.expose_primitive(unwrap_spec=[object, str])
 def primitiveDirectoryCreate(interp, s_frame, w_rcvr, dir_path):
+    # we actually should ask the security plugin function sCCPfn for permissions
     try:
         os.mkdir(dir_path, 0777)
     except OSError:
         raise PrimitiveFailedError
     return w_rcvr
 
-
 @FilePlugin.expose_primitive(unwrap_spec=[object, str])
 def primitiveDirectoryDelete(interp, s_frame, w_rcvr, dir_path):
+    # we actually should ask the security plugin function sCDPfn for permissions
     try:
         os.rmdir(dir_path)
     except OSError:

--- a/spyvm/test/test_external_calls.py
+++ b/spyvm/test/test_external_calls.py
@@ -46,6 +46,29 @@ def setup_module():
 def teardown_module():
     cleanup_module(__name__)
 
+def test_fileplugin_filedelete(monkeypatch):
+    def remove(file_path):
+        assert file_path == 'myFile'
+        return 0
+    monkeypatch.setattr(os, "remove", remove)
+    try:
+        stack = [space.w(1), space.wrap_string("myFile")]
+        w_c = external_call('FilePlugin', 'primitiveFileDelete', stack)
+    finally:
+        monkeypatch.undo()
+
+def test_fileplugin_filedelete_raises(monkeypatch):
+    def remove(file_path):
+        raise OSError()
+    monkeypatch.setattr(os, "remove", remove)
+
+    try:
+        with py.test.raises(PrimitiveFailedError):
+            stack = [space.w(1), space.wrap_string("myFile")]
+            w_c = external_call('FilePlugin', 'primitiveFileDelete', stack)
+    finally:
+        monkeypatch.undo()
+
 def test_fileplugin_dircreate(monkeypatch):
     def mkdir(dir_path, mode):
         assert dir_path == 'myPrimDir'

--- a/spyvm/test/test_external_calls.py
+++ b/spyvm/test/test_external_calls.py
@@ -1,0 +1,71 @@
+import py, os, math, time
+from spyvm import model, model_display, storage_contexts, constants, primitives, wrapper, display
+from spyvm.primitives import prim_table, PrimitiveFailedError
+from spyvm.plugins import bitblt
+from rpython.rlib.rfloat import isinf, isnan
+from rpython.rlib.rarithmetic import intmask, r_uint
+from rpython.rtyper.lltypesystem import lltype, rffi
+from .util import create_space, copy_to_module, cleanup_module, TestInterpreter, very_slow_test
+
+IMAGENAME = "anImage.image"
+
+def mock(space, stack, context = None):
+    mapped_stack = [space.w(x) for x in stack]
+    frame = context
+    for i in range(len(stack)):
+        frame.as_context_get_shadow(space).push(stack[i])
+    interp = TestInterpreter(space)
+    interp.space._image_name.set(IMAGENAME)
+    return interp, frame, len(stack)
+
+def _prim(space, code, stack, context = None):
+    interp, w_frame, argument_count = mock(space, stack, context)
+    prim_table[code](interp, w_frame.as_context_get_shadow(space), argument_count-1, context and context.as_context_get_shadow(space).w_method())
+    res = w_frame.as_context_get_shadow(space).pop()
+    s_frame = w_frame.as_context_get_shadow(space)
+    assert not s_frame.stackdepth() - s_frame.tempsize() # check args are consumed
+    return res
+
+def prim(code, stack, context = None):
+    return _prim(space, code, stack, context)
+
+def external_call(module_name, method_name, stack):
+    w_description = model.W_PointersObject(space, space.classtable['w_Array'], 2)
+    w_description.atput0(space, 0, space.w(module_name))
+    w_description.atput0(space, 1, space.w(method_name))
+    context = new_frame("<not called>", [w_description], stack[0], stack[1:])[0]
+    return prim(primitives.EXTERNAL_CALL, stack, context)
+
+def setup_module():
+    space = create_space(bootstrap = True)
+    wrap = space.w
+    bootstrap_class = space.bootstrap_class
+    new_frame = space.make_frame
+    copy_to_module(locals(), __name__)
+
+def teardown_module():
+    cleanup_module(__name__)
+
+def test_fileplugin_dircreate(monkeypatch):
+    def mkdir(dir_path, mode):
+        assert dir_path == 'myPrimDir'
+        assert mode == 0777
+        return 0
+    monkeypatch.setattr(os, "mkdir", mkdir)
+    try:
+        stack = [space.w(1), space.wrap_string("myPrimDir")]
+        w_c = external_call('FilePlugin', 'primitiveDirectoryCreate', stack)
+    finally:
+        monkeypatch.undo()
+
+def test_fileplugin_dircreate_raises(monkeypatch):
+    def mkdir(dir_path, mode):
+        raise OSError()
+    monkeypatch.setattr(os, "mkdir", mkdir)
+
+    try:
+        with py.test.raises(PrimitiveFailedError):
+            stack = [space.w(1), space.wrap_string("myPrimDir")]
+            w_c = external_call('FilePlugin', 'primitiveDirectoryCreate', stack)
+    finally:
+        monkeypatch.undo()

--- a/spyvm/test/test_external_calls.py
+++ b/spyvm/test/test_external_calls.py
@@ -69,3 +69,27 @@ def test_fileplugin_dircreate_raises(monkeypatch):
             w_c = external_call('FilePlugin', 'primitiveDirectoryCreate', stack)
     finally:
         monkeypatch.undo()
+
+
+def test_fileplugin_dirdelete(monkeypatch):
+    def rmdir(dir_path):
+        assert dir_path == 'myPrimDir'
+        return 0
+    monkeypatch.setattr(os, "rmdir", rmdir)
+    try:
+        stack = [space.w(1), space.wrap_string("myPrimDir")]
+        w_c = external_call('FilePlugin', 'primitiveDirectoryDelete', stack)
+    finally:
+        monkeypatch.undo()
+
+def test_fileplugin_dirdelete_raises(monkeypatch):
+    def rmdir(dir_path):
+        raise OSError()
+    monkeypatch.setattr(os, "rmdir", rmdir)
+
+    try:
+        with py.test.raises(PrimitiveFailedError):
+            stack = [space.w(1), space.wrap_string("myPrimDir")]
+            w_c = external_call('FilePlugin', 'primitiveDirectoryDelete', stack)
+    finally:
+        monkeypatch.undo()


### PR DESCRIPTION
# Done
- see #52 
- tests included
- Behavior differs from Cog: Cog calls some security plugin if present to check if those operations are allowed. If that security plugin is absent, Cog and Rsqueak will do the same. I think that's acceptable for now.
# Todo
- primitiveDirectoryEntry is not implemented yet. I guess we could simulate it with primLookupEntryIn:name:
- primitiveHasFileAccess is not implemented either and I don't think, we could simulate it
