### PR TITLE
Write floats with primitiveFileWrite

### DIFF
--- a/spyvm/model.py
+++ b/spyvm/model.py
@@ -15,7 +15,7 @@ import sys
 from spyvm import constants, error
 from spyvm.util.version import constant_for_version, constant_for_version_arg, VersionMixin, Version
 
-from rpython.rlib import rrandom, objectmodel, jit, signature
+from rpython.rlib import rrandom, objectmodel, jit, signature, longlong2float
 from rpython.rlib.rarithmetic import intmask, r_uint, r_int, ovfcheck, r_longlong
 from rpython.rlib.debug import make_sure_not_resized
 from rpython.tool.pairtype import extendabletype
@@ -184,6 +184,9 @@ class W_Object(object):
 
     def is_array_object(self):
         return False
+
+    def unwrap_string(self, space):
+        raise error.UnwrappingError
 
     # Methods for printing this object
 
@@ -455,6 +458,17 @@ class W_Float(W_AbstractObjectWithIdentityHash):
 
     def __init__(self, value):
         self.value = value
+
+    def unwrap_string(self, space):
+        word = longlong2float.float2longlong(self.value)
+        return "".join([chr(word & 0x000000ff),
+                        chr((word >> 8) & 0x000000ff),
+                        chr((word >> 16) & 0x000000ff),
+                        chr((word >> 24) & 0x000000ff),
+                        chr((word >> 32) & 0x000000ff),
+                        chr((word >> 40) & 0x000000ff),
+                        chr((word >> 48) & 0x000000ff),
+                        chr((word >> 56) & 0x000000ff)])
 
     def fillin(self, space, g_self):
         W_AbstractObjectWithIdentityHash.fillin(self, space, g_self)
@@ -867,9 +881,9 @@ class W_BytesObject(W_AbstractObjectWithClassReference):
         if self.has_class() and self.w_class.has_space():
             if self.w_class.space().omit_printing_raw_bytes.is_set():
                 return "<omitted>"
-        return "'%s'" % self.as_string().replace('\r', '\n')
+        return "'%s'" % self.unwrap_string(None).replace('\r', '\n')
 
-    def as_string(self):
+    def unwrap_string(self, space):
         return self._pure_as_string(self.version)
 
     @jit.elidable
@@ -880,7 +894,7 @@ class W_BytesObject(W_AbstractObjectWithClassReference):
             return "".join(self.bytes)
 
     def selector_string(self):
-        return "#" + self.as_string()
+        return "#" + self.unwrap_string(None)
 
     def invariant(self):
         if not W_AbstractObjectWithClassReference.invariant(self):
@@ -962,7 +976,7 @@ class W_BytesObject(W_AbstractObjectWithClassReference):
             return self.c_bytes
         else:
             size = self.size()
-            c_bytes = self.c_bytes = rffi.str2charp(self.as_string())
+            c_bytes = self.c_bytes = rffi.str2charp(self.unwrap_string(None))
             self.bytes = None
             self.mutate()
             return c_bytes
@@ -1035,8 +1049,8 @@ class W_WordsObject(W_AbstractObjectWithClassReference):
     def size(self):
         return self._size
 
-    @jit.look_inside_iff(lambda self: jit.isconstant(self.size()))
-    def as_string(self):
+    @jit.look_inside_iff(lambda self, space: jit.isconstant(self.size()))
+    def unwrap_string(self, space):
         # OH GOD! TODO: Make this sane!
         res = []
         for word in self.words:

--- a/spyvm/objspace.py
+++ b/spyvm/objspace.py
@@ -235,6 +235,9 @@ class ObjSpace(object):
     def unwrap_array(self, w_array):
         return w_array.unwrap_array(self)
 
+    def unwrap_string(self, w_object):
+        return w_object.unwrap_string(self)
+
     # ============= Access to static information =============
 
     @specialize.arg(1)

--- a/spyvm/plugins/fileplugin.py
+++ b/spyvm/plugins/fileplugin.py
@@ -189,19 +189,25 @@ def primitiveFileStdioHandles(interp, s_frame, w_rcvr):
 @FilePlugin.expose_primitive(unwrap_spec=[object, int, object, index1_0, int])
 def primitiveFileWrite(interp, s_frame, w_rcvr, fd, content, start, count):
     byte_size = 0
+    size = 0
     if isinstance(content, model.W_WordsObject):
         byte_size = 4
+        size = content.size()
     elif isinstance(content, model.W_BytesObject):
         byte_size = 1
+        size = content.size()
+    elif isinstance(content, model.W_Float):
+        byte_size = 4
+        # TODO: is there a case where a Float is only 32 bits?
+        size = 2
     else:
         raise PrimitiveFailedError
 
-    string_content = content.as_string()
+    string_content = interp.space.unwrap_string(content)
     byte_start = start * byte_size
-    byte_end = min(start + 1 + count, content.size()) * byte_size
+    byte_end = min(start + 1 + count, size) * byte_size
 
     space = interp.space
-
     if not (byte_start >= 0 and byte_end > byte_start):
         return space.wrap_int(0)
     try:

--- a/spyvm/plugins/vmdebugging.py
+++ b/spyvm/plugins/vmdebugging.py
@@ -57,7 +57,7 @@ def isVMTranslated(interp, s_frame, w_rcvr):
 def debugPrint(interp, s_frame, w_rcvr, w_string):
     if not isinstance(w_string, model.W_BytesObject):
         raise error.PrimitiveFailedError()
-    print w_string.as_string().replace('\r', '\n')
+    print interp.space.unwrap_string(w_string).replace('\r', '\n')
     return w_rcvr
 
 @DebuggingPlugin.expose_primitive(unwrap_spec=[object])

--- a/spyvm/primitives.py
+++ b/spyvm/primitives.py
@@ -138,7 +138,7 @@ def wrap_primitive(unwrap_spec=None, no_result=False,
                         args += (w_arg, )
                     elif spec is str:
                         assert isinstance(w_arg, model.W_BytesObject)
-                        args += (w_arg.as_string(), )
+                        args += (interp.space.unwrap_string(w_arg), )
                     elif spec is list:
                         assert isinstance(w_arg, model.W_PointersObject)
                         args += (interp.space.unwrap_array(w_arg), )
@@ -437,7 +437,7 @@ FAIL = 19
 
 def get_string(w_obj):
     if isinstance(w_obj, model.W_BytesObject):
-        return w_obj.as_string()
+        return w_obj.unwrap_string(None)
     return w_obj.as_repr_string()
 
 def exitFromHeadlessExecution(s_frame, selector="", w_message=None):
@@ -937,7 +937,7 @@ def func(interp, s_frame, argcount, w_method):
     if not (isinstance(w_modulename, model.W_BytesObject) and
             isinstance(w_functionname, model.W_BytesObject)):
         raise PrimitiveFailedError
-    signature = (w_modulename.as_string(), w_functionname.as_string())
+    signature = (space.unwrap_string(w_modulename), space.unwrap_string(w_functionname))
 
     if interp.space.use_plugins.is_set():
         from spyvm.plugins.squeak_plugin_proxy import IProxy, MissingPlugin

--- a/spyvm/squeakimage.py
+++ b/spyvm/squeakimage.py
@@ -286,7 +286,7 @@ class SqueakImage(object):
     def find_symbol(self, space, reader, symbol):
         w_dnu = self.special(constants.SO_DOES_NOT_UNDERSTAND)
         assert isinstance(w_dnu, model.W_BytesObject)
-        assert w_dnu.as_string() == "doesNotUnderstand:"
+        assert space.unwrap_string(w_dnu) == "doesNotUnderstand:"
         w_Symbol = w_dnu.getclass(space)
         w_obj = None
         # bit annoying that we have to hunt through the image :-(
@@ -296,7 +296,7 @@ class SqueakImage(object):
                 continue
             if not w_obj.getclass(space).is_same_object(w_Symbol):
                 continue
-            if w_obj.as_string() == symbol:
+            if space.unwrap_string(w_obj) == symbol:
                 return w_obj
         w_obj = space.w_nil
         return w_obj

--- a/spyvm/storage_classes.py
+++ b/spyvm/storage_classes.py
@@ -140,7 +140,7 @@ class ClassShadow(AbstractCachingShadow):
 
     def store_w_name(self, w_name):
         if isinstance(w_name, model.W_BytesObject):
-            self.name = w_name.as_string()
+            self.name = w_name.unwrap_string(None)
         else:
             self.name = None
 
@@ -319,7 +319,7 @@ class MethodDictionaryShadow(AbstractGenericShadow):
             w_selector = self.own_fetch(constants.METHODDICT_NAMES_INDEX+i)
             if not w_selector.is_nil(self.space):
                 if isinstance(w_selector, model.W_BytesObject):
-                    selector = w_selector.as_string()
+                    selector = w_selector.unwrap_string(None)
                 else:
                     selector = "? (non-byteobject selector)"
                     pass

--- a/spyvm/test/test_bootstrappedimage.py
+++ b/spyvm/test/test_bootstrappedimage.py
@@ -18,7 +18,7 @@ def test_symbol_asSymbol():
 def test_retrieve_symbol():
     space.initialize_class(space.w_String, interp)
     w_result = perform(w("someString"), "asSymbol")
-    assert w_result.as_string() == "someString"
+    assert w_result.unwrap_string(None) == "someString"
     w_anotherSymbol = perform(w("someString"), "asSymbol")
     assert w_result is w_anotherSymbol
 

--- a/spyvm/test/test_external_calls.py
+++ b/spyvm/test/test_external_calls.py
@@ -109,12 +109,13 @@ def test_fileplugin_filewrite_bytes(monkeypatch):
     def write(fd, data):
         assert len(data) == 4
         assert data == 'abcd'
+        return 4
     monkeypatch.setattr(os, "write", write)
 
     content = model.W_BytesObject(space, space.w_String, 4)
     content.bytes = ["a", "b", "c", "d"]
     try:
-        stack = [space.w(1), space.w(1), content, space.w(0), space.w(4)]
+        stack = [space.w(1), space.w(1), content, space.w(1), space.w(4)]
         w_c = external_call('FilePlugin', 'primitiveFileWrite', stack)
     finally:
         monkeypatch.undo()
@@ -123,12 +124,28 @@ def test_fileplugin_filewrite_words(monkeypatch):
     def write(fd, data):
         assert len(data) == 4
         assert data == 'dcba'
+        return 4
     monkeypatch.setattr(os, "write", write)
 
     content = model.W_WordsObject(space, space.w_String, 1)
     content.words = [rffi.r_uint(1633837924)]
     try:
-        stack = [space.w(1), space.w(1), content, space.w(0), space.w(1)]
+        stack = [space.w(1), space.w(1), content, space.w(1), space.w(1)]
+        w_c = external_call('FilePlugin', 'primitiveFileWrite', stack)
+    finally:
+        monkeypatch.undo()
+
+def test_fileplugin_filewrite_float(monkeypatch):
+    def write(fd, data):
+        assert len(data) == 8
+        assert data == 'hgfedcba'
+        return 4
+    monkeypatch.setattr(os, "write", write)
+
+    content = space.wrap_float(1.2926117907728089e+161)
+
+    try:
+        stack = [space.w(1), space.w(1), content, space.w(1), space.w(1)]
         w_c = external_call('FilePlugin', 'primitiveFileWrite', stack)
     finally:
         monkeypatch.undo()

--- a/spyvm/test/test_interpreter.py
+++ b/spyvm/test/test_interpreter.py
@@ -40,7 +40,7 @@ def assert_list(list, expected):
     for i in range(len(list)):
         exp = expected[i]
         if isinstance(exp, str):
-            assert exp == list[i].as_string()
+            assert exp == list[i].unwrap_string(None)
         if not isinstance(exp, model.W_Object):
             exp = w(exp)
         assert list[i].is_same_object(exp)
@@ -103,12 +103,12 @@ def test_create_frame():
     w_method._tempsize=8
     s_frame = w_method.create_frame(space, w("receiver"), [w("foo"), w("bar")])
     w_frame = s_frame.w_self()
-    assert s_frame.w_receiver().as_string() == "receiver"
-    assert s_frame.gettemp(0).as_string() == "foo"
-    assert s_frame.gettemp(1).as_string() == "bar"
+    assert s_frame.w_receiver().unwrap_string(None) == "receiver"
+    assert s_frame.gettemp(0).unwrap_string(None) == "foo"
+    assert s_frame.gettemp(1).unwrap_string(None) == "bar"
     assert s_frame.gettemp(2).is_nil(space)
     s_frame.settemp(2, w("spam"))
-    assert s_frame.gettemp(2).as_string() == "spam"
+    assert s_frame.gettemp(2).unwrap_string(None) == "spam"
     assert s_frame.fetch_next_bytecode() == ord("h")
     assert s_frame.fetch_next_bytecode() == ord("e")
     assert s_frame.fetch_next_bytecode() == ord("l")
@@ -861,8 +861,8 @@ def test_bc_pushNewArrayBytecode_noPopIntoArray(bytecode=pushNewArrayBytecode):
     assert array.size() == 2
     assert array.at0(space, 0).is_nil(space)
     assert array.at0(space, 1).is_nil(space)
-    assert s_frame.pop().as_string() == "bar"
-    assert s_frame.pop().as_string() == "egg"
+    assert s_frame.pop().unwrap_string(None) == "bar"
+    assert s_frame.pop().unwrap_string(None) == "egg"
 
 def test_bc_pushNewArray(bytecode=pushNewArrayBytecode):
     w_frame, s_frame = new_frame(bytecode + chr(0x07))
@@ -923,8 +923,8 @@ def test_bc_pushClosureCopyCopied2ValuesBytecode(bytecode = pushClosureCopyCopie
     closure = wrapper.BlockClosureWrapper(space, s_frame.top())
     assert closure.startpc() == pc + 4 + 5
     assert closure.outerContext() is s_frame._w_self
-    assert closure.at0(0).as_string() == "english"
-    assert closure.at0(1).as_string() == "bar"
+    assert closure.at0(0).unwrap_string(None) == "english"
+    assert closure.at0(1).unwrap_string(None) == "bar"
 
 def test_blockclosure_valuevalue():
     #someTest
@@ -971,13 +971,13 @@ def test_frame_not_dirty_if_inactive():
     step_in_interp(s_frame)
     assert s_frame.state is storage_contexts.ActiveContext
     assert s_other_frame.state is storage_contexts.InactiveContext
-    
+
 def test_raise_NonVirtualReturn_on_dirty_frame():
     bytes = reduce(operator.add, map(chr, [0x84, 0xc0, 0x00])) + returnTopFromMethodBytecode
     w_frame, s_frame = new_frame(bytes)
     s_frame.store_w_receiver(w_frame)
     s_frame.push(w_frame)
-    
+
     interp._loop = True
     def do_test():
         interp.stack_frame(s_frame, None)
@@ -1025,4 +1025,3 @@ def test_objectsAsMethods():
     assert w_runwithin_args[1].size() == 1 # foo: has one argument
     assert w_runwithin_args[1].fetch(space, 0) == w_holderobject # receiver was used as argument
     assert w_runwithin_args[2] == w_holderobject
-

--- a/spyvm/test/test_miniimage.py
+++ b/spyvm/test/test_miniimage.py
@@ -221,7 +221,7 @@ def test_step_forged_image():
 def test_create_new_symbol():
     w_result = perform(w("someString"), "asSymbol")
     assert w_result is not None
-    assert w_result.as_string() == "someString"
+    assert w_result.unwrap_string(None) == "someString"
 
 def test_create_new_symbol_new_with_arg0():
     w_dnu = image.special(constants.SO_DOES_NOT_UNDERSTAND)
@@ -263,12 +263,12 @@ def test_large_positive_integer_operation_times():
 def test_doesNotUnderstand():
     w_dnu = interp.space.objtable["w_doesNotUnderstand"]
     assert isinstance(w_dnu, model.W_BytesObject)
-    assert w_dnu.as_string() == "doesNotUnderstand:"
+    assert w_dnu.unwrap_string(None) == "doesNotUnderstand:"
 
 def test_mustBeBoolean():
     w_mbb = interp.space.objtable["w_mustBeBoolean"]
     assert isinstance(w_mbb, model.W_BytesObject)
-    assert w_mbb.as_string() == "mustBeBoolean"
+    assert w_mbb.unwrap_string(None) == "mustBeBoolean"
 
 def test_Message():
     w_message_cls = interp.space.w_Message
@@ -287,7 +287,7 @@ def test_primitive_perform_with_args():
     selectors_w = w_methoddict.strategy.methoddict.keys()
     w_sel = None
     for sel in selectors_w:
-        if sel.as_string() == 'size':
+        if sel.unwrap_string(None) == 'size':
             w_sel = sel
     size = _prim(space, primitives.PERFORM_WITH_ARGS, [w_o, w_sel, []])
     assert size.value == 3
@@ -313,10 +313,10 @@ def test_run_doesNotUnderstand():
     space, interp = runningSomethingImage()
     w_result = interp.perform(interp.space.wrap_int(0), "runningADNU")
     assert isinstance(w_result, model.W_BytesObject)
-    assert w_result.as_string() == "foobarThis:doesNotExist:('pypy' 'heya' )"
+    assert w_result.unwrap_string(None) == "foobarThis:doesNotExist:('pypy' 'heya' )"
 
 def test_run_mustBeBoolean():
     space, interp = runningSomethingImage()
     w_result = interp.perform(interp.space.wrap_int(0), "runningMustBeBoolean")
     assert isinstance(w_result, model.W_BytesObject)
-    assert w_result.as_string() == "mustBeBoolean has been called"
+    assert w_result.unwrap_string(None) == "mustBeBoolean has been called"

--- a/spyvm/test/test_primitives.py
+++ b/spyvm/test/test_primitives.py
@@ -577,13 +577,13 @@ def test_primitive_closure_copyClosure():
 
 # def test_primitive_string_copy():
 #     w_r = prim(primitives.STRING_REPLACE, ["aaaaa", 1, 5, "ababab", 1])
-#     assert w_r.as_string() == "ababa"
+#     assert w_r.unwrap_string(None) == "ababa"
 #     w_r = prim(primitives.STRING_REPLACE, ["aaaaa", 1, 5, "ababab", 2])
-#     assert w_r.as_string() == "babab"
+#     assert w_r.unwrap_string(None) == "babab"
 #     w_r = prim(primitives.STRING_REPLACE, ["aaaaa", 2, 5, "ccccc", 1])
-#     assert w_r.as_string() == "acccc"
+#     assert w_r.unwrap_string(None) == "acccc"
 #     w_r = prim(primitives.STRING_REPLACE, ["aaaaa", 2, 4, "ccccc", 1])
-#     assert w_r.as_string() == "accca"
+#     assert w_r.unwrap_string(None) == "accca"
 #     prim_fails(primitives.STRING_REPLACE, ["aaaaa", 0, 4, "ccccc", 1])
 #     prim_fails(primitives.STRING_REPLACE, ["aaaaa", 1, 6, "ccccc", 2])
 #     prim_fails(primitives.STRING_REPLACE, ["aaaaa", 2, 6, "ccccc", 1])
@@ -614,8 +614,8 @@ def test_primitive_closure_value_value():
     assert s_new_context.closure.wrapped is closure
     assert s_new_context.s_sender() is s_initial_context
     assert s_new_context.w_receiver().is_nil(space)
-    assert s_new_context.gettemp(0).as_string() == "first arg"
-    assert s_new_context.gettemp(1).as_string() == "second arg"
+    assert s_new_context.gettemp(0).unwrap_string(None) == "first arg"
+    assert s_new_context.gettemp(1).unwrap_string(None) == "second arg"
 
 def test_primitive_closure_value_value_with_temps():
     s_initial_context, closure, s_new_context = build_up_closure_environment(
@@ -625,9 +625,9 @@ def test_primitive_closure_value_value_with_temps():
     assert s_new_context.closure.wrapped is closure
     assert s_new_context.s_sender() is s_initial_context
     assert s_new_context.w_receiver().is_nil(space)
-    assert s_new_context.gettemp(0).as_string() == "first arg"
-    assert s_new_context.gettemp(1).as_string() == "second arg"
-    assert s_new_context.gettemp(2).as_string() == "some value"
+    assert s_new_context.gettemp(0).unwrap_string(None) == "first arg"
+    assert s_new_context.gettemp(1).unwrap_string(None) == "second arg"
+    assert s_new_context.gettemp(2).unwrap_string(None) == "some value"
 
 def test_primitive_some_instance():
     import gc; gc.collect()

--- a/spyvm/test/test_shadow.py
+++ b/spyvm/test/test_shadow.py
@@ -79,7 +79,7 @@ def test_methoddict():
     methoddict = classshadow.s_methoddict().methoddict
     assert len(methods) == len(methoddict)
     for w_key, value in methoddict.items():
-        assert methods[w_key.as_string()] is value
+        assert methods[w_key.unwrap_string(None)] is value
 
 def create_method(tempsize=3,argsize=2, bytes="abcde"):
     w_m = model.W_CompiledMethod(space, )
@@ -135,7 +135,7 @@ def test_context():
     assert s_object2.w_self() == w_object2
     assert s_object.s_sender() == None
     assert s_object2.s_sender() == s_object
-    assert s_object.w_receiver().as_string() == 'receiver'
+    assert s_object.w_receiver().unwrap_string(None) == 'receiver'
     s_object2.settemp(0, 'a')
     s_object2.settemp(1, 'b')
     assert s_object2.gettemp(1) == 'b'
@@ -145,14 +145,14 @@ def test_context():
     w_object.store(space, idx, space.wrap_string('f'))
     w_object.store(space, idx + 1, space.wrap_string('g'))
     w_object.store(space, idx + 2, space.wrap_string('h'))
-    assert map(lambda x: x.as_string(), s_object.stack()) == ['f', 'g', 'h' ]
-    assert s_object.top().as_string() == 'h'
+    assert map(lambda x: x.unwrap_string(None), s_object.stack()) == ['f', 'g', 'h' ]
+    assert s_object.top().unwrap_string(None) == 'h'
     s_object.push('i')
     assert s_object.top() == 'i'
-    assert s_object.peek(1).as_string() == 'h'
+    assert s_object.peek(1).unwrap_string(None) == 'h'
     assert s_object.pop() == 'i'
-    assert map(lambda x: x.as_string(), s_object.pop_and_return_n(2)) == ['g', 'h']
-    assert s_object.pop().as_string() == 'f'
+    assert map(lambda x: x.unwrap_string(None), s_object.pop_and_return_n(2)) == ['g', 'h']
+    assert s_object.pop().unwrap_string(None) == 'f'
     assert s_object.external_stackpointer() == s_object.stackstart() + s_object.tempsize()
     assert s_object.stackdepth() == s_object.tempsize()
 

--- a/spyvm/test/util.py
+++ b/spyvm/test/util.py
@@ -326,7 +326,7 @@ class BootstrappedObjSpace(objspace.ObjSpace):
         s_methoddict.sync_method_cache()
         methoddict_w = s_methoddict.methoddict
         for each in methoddict_w.keys():
-            if each.as_string() == string:
+            if each.unwrap_string(None) == string:
                 return each
         assert False, 'Using image without %s method in class %s.' % (string, cls.name)
 

--- a/targetrsqueak-embedded.py
+++ b/targetrsqueak-embedded.py
@@ -38,8 +38,7 @@ def entry_point(argv):
         interp.loop(s_frame.w_self())
     except interpreter.ReturnFromTopLevel, e:
         w_result = e.object
-        assert isinstance(w_result, model.W_BytesObject)
-        print w_result.as_string()
+        print interp.space.unwrap_string(w_result)
     return 0
 
 

--- a/targetrsqueak.py
+++ b/targetrsqueak.py
@@ -259,7 +259,7 @@ def compile_code(interp, w_receiver, code):
         space.w_nil]
     )
     # TODO - is this expected in every image?
-    if not isinstance(w_result, model.W_BytesObject) or w_result.as_string() != selector:
+    if not isinstance(w_result, model.W_BytesObject) or space.unwrap_string(w_result) != selector:
         raise error.Exit("Unexpected compilation result (probably failed to compile): %s" % result_string(w_result))
     space.suppress_process_switch.deactivate()
 


### PR DESCRIPTION
This PR adds support for writing floats (#74).

However, the following code writes 4 bytes in RSqueak and 8 bytes in COG. Could this be due to the fact that I am running 32-bit RSqueak and 64-bit COG?

``` smalltalk
| stream |
stream := FileStream newFileNamed: '/tmp/stream_1'.
stream binary.
stream nextPutAll: 4.5
```

Also notice that the VMMaker code always writes 1 byte or 4 bytes:

``` smalltalk
    (interpreterProxy isWords: array)
        ifTrue: [byteSize := 4]
        ifFalse: [byteSize := 1].
```
