### PR TITLE
use the new interface to attach gdb

### DIFF
--- a/spyvm/plugins/vmdebugging.py
+++ b/spyvm/plugins/vmdebugging.py
@@ -40,12 +40,9 @@ def untrace_proxy(interp, s_frame, w_rcvr):
 
 @DebuggingPlugin.expose_primitive(unwrap_spec=[object])
 def halt(interp, s_frame, w_rcvr):
+    from rpython.rlib.debug import attach_gdb
     print s_frame.print_stack()
-    from rpython.config.translationoption import get_translation_config
-    from rpython.rlib.objectmodel import we_are_translated
-    if not we_are_translated() or get_translation_config().translation.lldebug or get_translation_config().translation.lldebug0:
-        import pdb; pdb.set_trace()
-    raise error.PrimitiveFailedError
+    attach_gdb()
 
 @DebuggingPlugin.expose_primitive(unwrap_spec=[object])
 def isRSqueak(interp, s_frame, w_rcvr):


### PR DESCRIPTION
The interface in RPython for attaching GDB has changed, update to new interface.
