### PR TITLE
Buildscript readability

### DIFF
--- a/.build/build.py
+++ b/.build/build.py
@@ -3,10 +3,10 @@
 import sys, os
 
 if __name__ == "__main__":
-    if not reduce(bool.__or__, [arg.startswith("-O") for arg in sys.argv]):
+    if not any(arg.startswith("-O") for arg in sys.argv):
         sys.argv.append("--batch")
         sys.argv.append("-Ojit")
-    if not reduce(bool.__or__, [arg.startswith("--gcrootfinder") for arg in sys.argv]):
+    if not any(arg.startswith("--gcrootfinder") for arg in sys.argv):
         # default to shadowstack, so all platforms are created equal
         # (and also because asmgcc doesn't work when cross-compiling
         # on Linux, where it is the default)

--- a/.build/jittests.py
+++ b/.build/jittests.py
@@ -1,18 +1,18 @@
 #! /usr/bin/env python
 
-import sys, zlib, base64
+import sys
 from os import path
 from environment import cp, config
 
 if __name__ == "__main__":
-    if not reduce(bool.__or__, [arg.startswith("--jit") for arg in sys.argv]):
+    if not any(arg.startswith("--jit") for arg in sys.argv):
         sys.argv.append("--jit=%s" % path.join(path.dirname(__file__), "..", "rsqueak"))
-    if not reduce(bool.__or__, [arg.startswith("--squeak") for arg in sys.argv]):
+    if not any(arg.startswith("--squeak") for arg in sys.argv):
         squeak = cp.get("General", "squeak")
         if not path.exists(squeak):
             print "WARN: You need to configure where to find the squeak binary in %s to run the full suite of JIT tests" % config
         sys.argv.append("--squeak=%s" % squeak)
-    if not reduce(bool.__or__, [arg.find("jittest/test") != -1 for arg in sys.argv]):
+    if not any(arg.find("jittest/test") != -1 for arg in sys.argv):
         sys.argv.append(path.join(path.dirname(__file__), "..", "spyvm", "test", "jittest"))
 
     import pytest

--- a/.build/shell.py
+++ b/.build/shell.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python
 
-import sys, os, subprocess
+import sys, os
 
 if __name__ == "__main__":
     import environment, code

--- a/.build/unittests.py
+++ b/.build/unittests.py
@@ -2,13 +2,12 @@
 
 #! /usr/bin/env python
 
-import sys, zlib, base64
+import sys
 from os import path
-from environment import cp
+import environment
 
 if __name__ == "__main__":
-    if not reduce(bool.__or__, [arg.find("/test") != -1 or arg.find("\\test") != -1
-                                for arg in sys.argv]):
+    if not any("/test" in arg or "\\test" in arg for arg in sys.argv):
         sys.argv.append(path.join(path.dirname(__file__), "..", "spyvm", "test"))
 
     import pytest


### PR DESCRIPTION
I assume the idiomatic way to say `reduce(bool.__or__, ...)` is `any(...)` :-)

Also removing some unused module imports.
