### PR TITLE
Emulate headless when running code or selector

### DIFF
--- a/targetrsqueak.py
+++ b/targetrsqueak.py
@@ -387,6 +387,10 @@ def entry_point(argv):
         print_error("%s -- %s (LoadError)" % (os.strerror(e.errno), cfg.path))
         return 1
 
+    if cfg.code or cfg.selector:
+        # Mark headless mode when running code or selector
+        argv.append('-headless')
+
     # Load & prepare image and environment
     image = squeakimage.ImageReader(space, stream).create_image()
     interp = interpreter.Interpreter(space, image,


### PR DESCRIPTION
By passing a fake argument `-headless` to the image when running in an
implicit headless environment due to `-r` or `-m` evaluating `Smalltalk
isHeadless` will return `true` now.

Signed-Off: @fniephaus
