### PR TITLE
Fix a recent segfault and refactor simulation code

### DIFF
--- a/rsqueakvm/error.py
+++ b/rsqueakvm/error.py
@@ -57,15 +57,3 @@ class CorruptImageError(Exit):
 class CleanExit(Exit):
     def __init__(self, msg=""):
         Exit.__init__(self, msg)
-
-class MetaPrimFailed(SmalltalkException):
-    """
-    Indicates that the simulated primitive code failed and that the fallback
-    code should be invoked.
-    """
-    exception_type = "MetaPrimFailed"
-    _attrs_ = ["s_frame", "error_code"]
-
-    def __init__(self, s_frame, error_code):
-        self.s_frame = s_frame
-        self.error_code = error_code

--- a/rsqueakvm/interpreter.py
+++ b/rsqueakvm/interpreter.py
@@ -4,7 +4,7 @@ import sys
 sys.setrecursionlimit(1000000)
 
 from rsqueakvm import constants, wrapper, objspace, interpreter_bytecodes
-from rsqueakvm.error import MetaPrimFailed, FatalError
+from rsqueakvm.error import FatalError
 from rsqueakvm.model.compiled_methods import W_PreSpurCompiledMethod, W_SpurCompiledMethod
 from rsqueakvm.model.numeric import W_SmallInteger
 from rsqueakvm.storage_contexts import ContextPartShadow, ActiveContext, InactiveContext, DirtyContext
@@ -217,8 +217,6 @@ class Interpreter(object):
                 if self.is_tracing() or self.trace_important:
                     ret.print_trace()
                 s_context = self.unwind_context_chain(ret.s_current_context, ret.s_target_context, ret.w_value, s_context)
-            except MetaPrimFailed, e:
-                s_context = self.unwind_primitive_simulation(e.s_frame, e.error_code, s_context)
 
     # This is a wrapper around loop_bytecodes that cleanly enters/leaves the frame,
     # handles the stack overflow protection mechanism and handles/dispatches Returns.
@@ -288,23 +286,18 @@ class Interpreter(object):
                 else:
                     raise ret
 
-    def unwind_primitive_simulation(self, start_context, error_code, s_current_context):
-        if start_context is None:
-            # This is the toplevel frame. Execution ended.
-            raise ReturnFromTopLevel(self.space.w_nil, s_current_context)
+    def unwind_primitive_simulation(self, start_context, error_code):
         context = start_context
         while context.get_fallback() is None:
             s_sender = context.s_sender()
-            context._activate_unwind_context(self)
             context = s_sender
-
             if not context:
                 msg = "Context chain ended while trying to unwind primitive simulation\nfrom\n%s\n(pc %s)" % (
                         start_context.short_str(),
                         start_context.pc())
                 raise FatalError(msg)
-
         fallbackContext = context.get_fallback()
+        fallbackContext.store_s_sender(context.s_sender())
 
         if fallbackContext.tempsize() > len(fallbackContext.w_arguments()):
             fallbackContext.settemp(len(fallbackContext.w_arguments()), self.space.wrap_int(error_code))

--- a/rsqueakvm/plugins/simulation.py
+++ b/rsqueakvm/plugins/simulation.py
@@ -1,5 +1,6 @@
 from rsqueakvm.error import SimulatedPrimitiveFailedError
 from rsqueakvm.plugins.plugin import Plugin
+from rsqueakvm.model.compiled_methods import W_CompiledMethod
 
 # If an EXTERNAL_CALL for the given moduleName and functionName is not found,
 # the SimulationPlugin is used to enable the image simulating that primitive.
@@ -21,34 +22,27 @@ SIMULATE_PRIMITIVE_SELECTOR = 'simulatePrimitive:args:'
 
 class SimulationPluginClass(Plugin):
     def _simulate(self, w_name, interp, s_frame, argcount, w_method):
-        w_arguments = s_frame.peek_n(argcount)
         w_rcvr = s_frame.peek(argcount)
-
         s_class = w_rcvr.class_shadow(interp.space)
-
         if not interp.image.w_simulatePrimitive or interp.image.w_simulatePrimitive.is_nil(interp.space):
             raise SimulatedPrimitiveFailedError("Primitive has failed and simulator selector not in image", w_name, s_class)
-
         w_sim_method = s_class.lookup(interp.image.w_simulatePrimitive)
         if w_sim_method is None:
             raise SimulatedPrimitiveFailedError("Primitive has failed and no simulator method was found on this class", w_name, s_class)
+        if not isinstance(w_sim_method, W_CompiledMethod):
+            raise SimulatedPrimitiveFailedError("Simulator method must be an ordinary compiled method", w_name, s_class)
 
-        s_frame.push(w_rcvr)
-        s_frame.push(w_name)
-        s_frame.push(interp.space.wrap_list_unroll_safe(w_arguments))
+        w_arguments = s_frame.pop_and_return_n(argcount)
+        s_frame.pop() # remove receiver
 
         s_fallback = w_method.create_frame(interp.space, w_rcvr, w_arguments)
         s_fallback._s_sender = s_frame
-
-        from rsqueakvm.interpreter import Return
-
-        try:
-            s_frame._sendSelector(interp.image.w_simulatePrimitive, 2, interp, w_rcvr, w_rcvr.class_shadow(interp.space), s_fallback=s_fallback)
-        except Return, ret:
-            # must clean the stack, including the rcvr
-            s_frame.pop_n(argcount + 1)
-            s_frame.push(ret.value(interp.space))
-            return w_rcvr
+        s_sim_frame = w_sim_method.create_frame(
+            interp.space,
+            w_rcvr,
+            [w_name, interp.space.wrap_list_unroll_safe(w_arguments)],
+            s_fallback=s_fallback)
+        interp.stack_frame(s_sim_frame, s_frame)
 
     def simulate(self, w_name, signature, interp, s_frame, argcount, w_method):
         self._simulate(w_name, interp, s_frame, argcount, w_method)

--- a/rsqueakvm/primitives/system.py
+++ b/rsqueakvm/primitives/system.py
@@ -40,6 +40,7 @@ def func(interp, s_frame, w_rcvr, primFailFlag):
     from rsqueakvm.storage_contexts import DirtyContext
     if primFailFlag != 0:
         s_fallback = interp.unwind_primitive_simulation(s_frame, primFailFlag)
+        s_fallback.state = DirtyContext
         return s_fallback
     raise PrimitiveFailedError
 

--- a/rsqueakvm/primitives/system.py
+++ b/rsqueakvm/primitives/system.py
@@ -1,7 +1,7 @@
 from rpython.rlib import jit, objectmodel
 
 from rsqueakvm import constants
-from rsqueakvm.error import PrimitiveFailedError, MetaPrimFailed
+from rsqueakvm.error import PrimitiveFailedError
 from rsqueakvm.model.numeric import W_SmallInteger
 from rsqueakvm.primitives import expose_primitive
 from rsqueakvm.primitives.bytecodes import *
@@ -35,10 +35,12 @@ def func(interp, s_frame, w_rcvr, flag):
 # ___________________________________________________________________________
 # VM implementor primitives
 
-@expose_primitive(META_PRIM_FAILED, unwrap_spec=[object, int])
+@expose_primitive(META_PRIM_FAILED, unwrap_spec=[object, int], result_is_new_frame=True)
 def func(interp, s_frame, w_rcvr, primFailFlag):
+    from rsqueakvm.storage_contexts import DirtyContext
     if primFailFlag != 0:
-        raise MetaPrimFailed(s_frame, primFailFlag)
+        s_fallback = interp.unwind_primitive_simulation(s_frame, primFailFlag)
+        return s_fallback
     raise PrimitiveFailedError
 
 @expose_primitive(VM_PARAMETERS)

--- a/targetrsqueak.py
+++ b/targetrsqueak.py
@@ -377,7 +377,7 @@ class Config(object):
 
 
 def entry_point(argv):
-    jit.set_param(None, "trace_limit", 1000000)
+    jit.set_param(None, "trace_limit", 16000)
     # == Main execution parameters
     space = prebuilt_space
     cfg = Config(space, argv)


### PR DESCRIPTION
Some recent pypy update started to cause segfaults when aborting too long traces when the trace limit is very high. Setting it lower by default helps, and at least doesn't seem to have an adverse effect on UI responsiveness. I haven't run benchmarks, however, so we should see what codespeed says.

The other refactoring in there is to speed up simulation when the code is not jitted, which also (hopefully) makes it a little clearer.
