### PR TITLE
Immutable object tests

### DIFF
--- a/rsqueakvm/test/test_external_calls.py
+++ b/rsqueakvm/test/test_external_calls.py
@@ -7,44 +7,13 @@ from rsqueakvm.model.display import W_DisplayBitmap
 from rsqueakvm.model.pointers import W_PointersObject
 from rsqueakvm.model.numeric import W_LargeIntegerWord
 from rsqueakvm.model.variable import W_BytesObject, W_WordsObject
-from rsqueakvm.primitives import prim_table
-from rsqueakvm.primitives.constants import EXTERNAL_CALL
 
 from rpython.rtyper.lltypesystem import rffi
 from rpython.rlib.rbigint import rbigint
 from rpython.rlib.rarithmetic import r_uint
 
-from .util import create_space, copy_to_module, cleanup_module, InterpreterForTest, read_image
+from .util import create_space, copy_to_module, cleanup_module, InterpreterForTest, read_image, external_call
 
-IMAGENAME = "anImage.image"
-
-def mock(space, stack, context = None):
-    mapped_stack = [space.w(x) for x in stack]
-    frame = context
-    for i in range(len(stack)):
-        frame.as_context_get_shadow(space).push(stack[i])
-    interp = InterpreterForTest(space)
-    interp.space.set_system_attribute(constants.SYSTEM_ATTRIBUTE_IMAGE_NAME_INDEX, IMAGENAME)
-    return interp, frame, len(stack)
-
-def _prim(space, code, stack, context = None):
-    interp, w_frame, argument_count = mock(space, stack, context)
-    prim_table[code](interp, w_frame.as_context_get_shadow(space), argument_count-1, context and context.as_context_get_shadow(space).w_method())
-    res = w_frame.as_context_get_shadow(space).pop()
-    s_frame = w_frame.as_context_get_shadow(space)
-    assert not s_frame.stackdepth() - s_frame.tempsize()  # check args are consumed
-    return res
-
-def prim(code, stack, context = None):
-    return _prim(space, code, stack, context)
-
-def external_call(module_name, method_name, stack):
-    stack = [space.w(o) for o in stack]
-    w_description = W_PointersObject(space, space.w_Array, 2)
-    w_description.atput0(space, 0, space.w(module_name))
-    w_description.atput0(space, 1, space.w(method_name))
-    context = new_frame("<not called>", [w_description], stack[0], stack[1:])[0]
-    return prim(EXTERNAL_CALL, stack, context)
 
 def setup_module():
     space = create_space(bootstrap = True)
@@ -63,7 +32,7 @@ def test_fileplugin_filedelete(monkeypatch):
     monkeypatch.setattr(os, "remove", remove)
     try:
         stack = [space.w(1), space.wrap_string("myFile")]
-        w_c = external_call('FilePlugin', 'primitiveFileDelete', stack)
+        w_c = external_call(space, 'FilePlugin', 'primitiveFileDelete', stack)
     finally:
         monkeypatch.undo()
 
@@ -75,7 +44,7 @@ def test_fileplugin_filedelete_raises(monkeypatch):
     try:
         with py.test.raises(PrimitiveFailedError):
             stack = [space.w(1), space.wrap_string("myFile")]
-            w_c = external_call('FilePlugin', 'primitiveFileDelete', stack)
+            w_c = external_call(space, 'FilePlugin', 'primitiveFileDelete', stack)
     finally:
         monkeypatch.undo()
 
@@ -87,7 +56,7 @@ def test_fileplugin_dircreate(monkeypatch):
     monkeypatch.setattr(os, "mkdir", mkdir)
     try:
         stack = [space.w(1), space.wrap_string("myPrimDir")]
-        w_c = external_call('FilePlugin', 'primitiveDirectoryCreate', stack)
+        w_c = external_call(space, 'FilePlugin', 'primitiveDirectoryCreate', stack)
     finally:
         monkeypatch.undo()
 
@@ -99,7 +68,7 @@ def test_fileplugin_dircreate_raises(monkeypatch):
     try:
         with py.test.raises(PrimitiveFailedError):
             stack = [space.w(1), space.wrap_string("myPrimDir")]
-            w_c = external_call('FilePlugin', 'primitiveDirectoryCreate', stack)
+            w_c = external_call(space, 'FilePlugin', 'primitiveDirectoryCreate', stack)
     finally:
         monkeypatch.undo()
 
@@ -111,7 +80,7 @@ def test_fileplugin_dirdelete(monkeypatch):
     monkeypatch.setattr(os, "rmdir", rmdir)
     try:
         stack = [space.w(1), space.wrap_string("myPrimDir")]
-        w_c = external_call('FilePlugin', 'primitiveDirectoryDelete', stack)
+        w_c = external_call(space, 'FilePlugin', 'primitiveDirectoryDelete', stack)
     finally:
         monkeypatch.undo()
 
@@ -126,7 +95,7 @@ def test_fileplugin_filewrite_bytes(monkeypatch):
     content.bytes = ["a", "b", "c", "d"]
     try:
         stack = [space.w(1), space.w(1), content, space.w(1), space.w(4)]
-        w_c = external_call('FilePlugin', 'primitiveFileWrite', stack)
+        w_c = external_call(space, 'FilePlugin', 'primitiveFileWrite', stack)
     finally:
         monkeypatch.undo()
 
@@ -141,7 +110,7 @@ def test_fileplugin_filewrite_words(monkeypatch):
     content.words = [rffi.r_uint(1633837924)]
     try:
         stack = [space.w(1), space.w(1), content, space.w(1), space.w(1)]
-        w_c = external_call('FilePlugin', 'primitiveFileWrite', stack)
+        w_c = external_call(space, 'FilePlugin', 'primitiveFileWrite', stack)
     finally:
         monkeypatch.undo()
 
@@ -156,7 +125,7 @@ def test_fileplugin_filewrite_float(monkeypatch):
 
     try:
         stack = [space.w(1), space.w(1), content, space.w(1), space.w(1)]
-        w_c = external_call('FilePlugin', 'primitiveFileWrite', stack)
+        w_c = external_call(space, 'FilePlugin', 'primitiveFileWrite', stack)
     finally:
         monkeypatch.undo()
 
@@ -170,13 +139,13 @@ def test_fileplugin_filewrite_largeposint(monkeypatch):
     content = W_LargeIntegerWord(space, space.w_LargePositiveInteger, r_uint(1633837924), 4)
     try:
         stack = [space.w(1), space.w(1), content, space.w(1), space.w(4)]
-        w_c = external_call('FilePlugin', 'primitiveFileWrite', stack)
+        w_c = external_call(space, 'FilePlugin', 'primitiveFileWrite', stack)
     finally:
         monkeypatch.undo()
 
 def test_fileplugin_filewrite_pointers(monkeypatch):
     with py.test.raises(PrimitiveFailedError):
-        external_call('FilePlugin', 'primitiveFileWrite', [1, 1, None, 1, 1])
+        external_call(space, 'FilePlugin', 'primitiveFileWrite', [1, 1, None, 1, 1])
 
 def test_fileplugin_filewrite_bitmap(monkeypatch):
     def write(fd, data):
@@ -189,7 +158,7 @@ def test_fileplugin_filewrite_bitmap(monkeypatch):
     content._real_depth_buffer[0] = rffi.r_uint(1633837924)
     try:
         stack = [space.w(1), space.w(1), content, space.w(1), space.w(1)]
-        w_c = external_call('FilePlugin', 'primitiveFileWrite', stack)
+        w_c = external_call(space, 'FilePlugin', 'primitiveFileWrite', stack)
     finally:
         monkeypatch.undo()
 
@@ -201,19 +170,19 @@ def test_fileplugin_dirdelete_raises(monkeypatch):
     try:
         with py.test.raises(PrimitiveFailedError):
             stack = [space.w(1), space.wrap_string("myPrimDir")]
-            w_c = external_call('FilePlugin', 'primitiveDirectoryDelete', stack)
+            w_c = external_call(space, 'FilePlugin', 'primitiveDirectoryDelete', stack)
     finally:
         monkeypatch.undo()
 
 def test_fileplugin_stdio_handles():
-    handles = space.unwrap_array(external_call('FilePlugin', 'primitiveFileStdioHandles', [None]))
+    handles = space.unwrap_array(external_call(space, 'FilePlugin', 'primitiveFileStdioHandles', [None]))
     assert handles[0].value == 0
     assert handles[1].value == 1
     assert handles[2].value == 2
 
 def test_fileplugin_path_sep():
     import os
-    sep = chr(external_call('FilePlugin', 'primitiveDirectoryDelimitor', [None]).value)
+    sep = chr(external_call(space, 'FilePlugin', 'primitiveDirectoryDelimitor', [None]).value)
     assert sep == os.path.sep
 
 def test_fileplugin_dir_lookup(monkeypatch):
@@ -236,16 +205,16 @@ def test_fileplugin_dir_lookup(monkeypatch):
     monkeypatch.setattr(os, "stat", stat)
     try:
         result = space.unwrap_array(
-            external_call("FilePlugin", "primitiveDirectoryLookup", [None, '', 1]))
+            external_call(space, "FilePlugin", "primitiveDirectoryLookup", [None, '', 1]))
         assert result[0].unwrap_string(space) == "foo"
         assert result[1].unwrap_long_untranslated(space) > realstat.st_ctime
         assert result[2].unwrap_long_untranslated(space) > realstat.st_mtime
         assert result[3] is space.w_false
         assert result[4].unwrap_long_untranslated(space) == realstat.st_size
         with py.test.raises(PrimitiveFailedError):
-            external_call("FilePlugin", "primitiveDirectoryLookup", [None, '/rsqueaktest/', 4])
+            external_call(space, "FilePlugin", "primitiveDirectoryLookup", [None, '/rsqueaktest/', 4])
         with py.test.raises(PrimitiveFailedError):
-            external_call("FilePlugin", "primitiveDirectoryLookup", [None, '/rsqueaktest/', 2])
+            external_call(space, "FilePlugin", "primitiveDirectoryLookup", [None, '/rsqueaktest/', 2])
     finally:
         monkeypatch.undo()
 
@@ -264,16 +233,16 @@ def test_fileplugin_file_open(monkeypatch):
     monkeypatch.setattr(os, "open", open)
     try:
         required_mode = os.O_RDWR | os.O_CREAT
-        assert external_call("FilePlugin", "primitiveFileOpen", [None, "new_file", True]).value == 32
+        assert external_call(space, "FilePlugin", "primitiveFileOpen", [None, "new_file", True]).value == 32
         required_mode = os.O_RDWR
-        assert external_call("FilePlugin", "primitiveFileOpen", [None, __file__, True]).value == 32
+        assert external_call(space, "FilePlugin", "primitiveFileOpen", [None, __file__, True]).value == 32
         required_mode = os.O_RDONLY
-        assert external_call("FilePlugin", "primitiveFileOpen", [None, __file__, False]).value == 32
+        assert external_call(space, "FilePlugin", "primitiveFileOpen", [None, __file__, False]).value == 32
         required_mode = os.O_RDONLY
-        assert external_call("FilePlugin", "primitiveFileOpen", [None, __file__, False]).value == 32
-        assert external_call("FilePlugin", "primitiveFileOpen", [None, "new_file", False]) is space.w_nil
+        assert external_call(space, "FilePlugin", "primitiveFileOpen", [None, __file__, False]).value == 32
+        assert external_call(space, "FilePlugin", "primitiveFileOpen", [None, "new_file", False]) is space.w_nil
         with py.test.raises(PrimitiveFailedError):
-            external_call("FilePlugin", "primitiveDirectoryLookup",
+            external_call(space, "FilePlugin", "primitiveDirectoryLookup",
                           [None, os.path.dirname(__file__), True])
     finally:
         monkeypatch.undo()
@@ -283,32 +252,32 @@ def test_fileplugin_file_close(monkeypatch):
     def dontclose(fd): raise OSError
     try:
         monkeypatch.setattr(os, "close", doclose)
-        assert external_call("FilePlugin", "primitiveFileClose", [None, 32]) is space.w_nil
+        assert external_call(space, "FilePlugin", "primitiveFileClose", [None, 32]) is space.w_nil
         monkeypatch.setattr(os, "close", dontclose)
         with py.test.raises(PrimitiveFailedError):
-            external_call("FilePlugin", "primitiveFileClose", [None, 32])
+            external_call(space, "FilePlugin", "primitiveFileClose", [None, 32])
     finally:
         monkeypatch.undo()
 
 def test_fileplugin_file_atend(monkeypatch):
     fd = os.open(__file__, os.O_RDONLY)
     try:
-        assert external_call("FilePlugin", "primitiveFileAtEnd", [None, fd]) is space.w_false
+        assert external_call(space, "FilePlugin", "primitiveFileAtEnd", [None, fd]) is space.w_false
         os.lseek(fd, 0, os.SEEK_END)
-        assert external_call("FilePlugin", "primitiveFileAtEnd", [None, fd]) is space.w_true
+        assert external_call(space, "FilePlugin", "primitiveFileAtEnd", [None, fd]) is space.w_true
     finally:
         os.close(fd)
 
 def test_fileplugin_file_read(monkeypatch):
     with py.test.raises(PrimitiveFailedError):
-        external_call("FilePlugin", "primitiveFileRead", [None, 32, None, 1, 12])
+        external_call(space, "FilePlugin", "primitiveFileRead", [None, 32, None, 1, 12])
 
     def raiseread(fd, count):
         raise OSError
     monkeypatch.setattr(os, "read", raiseread)
     try:
         with py.test.raises(PrimitiveFailedError):
-            external_call("FilePlugin", "primitiveFileRead", [None, 32, "hello", 1, 5])
+            external_call(space, "FilePlugin", "primitiveFileRead", [None, 32, "hello", 1, 5])
     finally:
         monkeypatch.undo()
 
@@ -318,16 +287,16 @@ def test_fileplugin_file_read(monkeypatch):
     monkeypatch.setattr(os, "read", read)
     try:
         with py.test.raises(PrimitiveFailedError):
-            external_call("FilePlugin", "primitiveFileRead", [None, 32, "123", 1, 5])
+            external_call(space, "FilePlugin", "primitiveFileRead", [None, 32, "123", 1, 5])
         with py.test.raises(PrimitiveFailedError):
-            external_call("FilePlugin", "primitiveFileRead", [None, 32, "12345", 2, 5])
+            external_call(space, "FilePlugin", "primitiveFileRead", [None, 32, "12345", 2, 5])
 
         w_out = space.w("123456")
-        assert external_call("FilePlugin", "primitiveFileRead", [None, 32, w_out, 1, 5]).value == 5
+        assert external_call(space, "FilePlugin", "primitiveFileRead", [None, 32, w_out, 1, 5]).value == 5
         assert w_out.unwrap_string(space) == "hello6"
 
         w_out = space.w("123456")
-        assert external_call("FilePlugin", "primitiveFileRead", [None, 32, w_out, 2, 5]).value == 5
+        assert external_call(space, "FilePlugin", "primitiveFileRead", [None, 32, w_out, 2, 5]).value == 5
         assert w_out.unwrap_string(space) == "1hello"
     finally:
         monkeypatch.undo()
@@ -336,10 +305,10 @@ def test_fileplugin_file_get_position(monkeypatch):
     fd = os.open(__file__, os.O_RDONLY)
     try:
         with py.test.raises(PrimitiveFailedError):
-            external_call("FilePlugin", "primitiveFileGetPosition", [None, -1])
-        assert external_call("FilePlugin", "primitiveFileGetPosition", [None, fd]).value == 0
+            external_call(space, "FilePlugin", "primitiveFileGetPosition", [None, -1])
+        assert external_call(space, "FilePlugin", "primitiveFileGetPosition", [None, fd]).value == 0
         os.lseek(fd, 32, os.SEEK_CUR)
-        assert external_call("FilePlugin", "primitiveFileGetPosition", [None, fd]).value == 32
+        assert external_call(space, "FilePlugin", "primitiveFileGetPosition", [None, fd]).value == 32
     finally:
         os.close(fd)
 
@@ -347,8 +316,8 @@ def test_fileplugin_file_set_position(monkeypatch):
     fd = os.open(__file__, os.O_RDONLY)
     try:
         with py.test.raises(PrimitiveFailedError):
-            external_call("FilePlugin", "primitiveFileSetPosition", [None, -1, 32])
-        external_call("FilePlugin", "primitiveFileSetPosition", [None, fd, 32])
+            external_call(space, "FilePlugin", "primitiveFileSetPosition", [None, -1, 32])
+        external_call(space, "FilePlugin", "primitiveFileSetPosition", [None, fd, 32])
         assert os.lseek(fd, 0, os.SEEK_CUR) == 32
     finally:
         os.close(fd)
@@ -357,8 +326,8 @@ def test_fileplugin_file_size(monkeypatch):
     fd = os.open(__file__, os.O_RDONLY)
     try:
         with py.test.raises(PrimitiveFailedError):
-            external_call("FilePlugin", "primitiveFileSize", [None, -1])
-        assert external_call("FilePlugin", "primitiveFileSize", [None, fd]).value == os.fstat(fd).st_size
+            external_call(space, "FilePlugin", "primitiveFileSize", [None, -1])
+        assert external_call(space, "FilePlugin", "primitiveFileSize", [None, fd]).value == os.fstat(fd).st_size
     finally:
         os.close(fd)
 
@@ -370,10 +339,10 @@ def test_fileplugin_file_truncate(monkeypatch):
     def failtrunc(fd, p): raise OSError
     monkeypatch.setattr(file_plugin, "ftruncate", truncate)
     try:
-        external_call("FilePlugin", "primitiveFileTruncate", [None, 32, 12])
+        external_call(space, "FilePlugin", "primitiveFileTruncate", [None, 32, 12])
         monkeypatch.setattr(file_plugin, "ftruncate", failtrunc)
         with py.test.raises(PrimitiveFailedError):
-            external_call("FilePlugin", "primitiveFileTruncate", [None, 32, 12])
+            external_call(space, "FilePlugin", "primitiveFileTruncate", [None, 32, 12])
     finally:
         monkeypatch.undo()
 
@@ -383,14 +352,14 @@ def test_locale_plugin_primLang_fails(monkeypatch):
         return "C"
     monkeypatch.setattr(rlocale, "setlocale", setlocale)
     with py.test.raises(PrimitiveFailedError):
-        external_call('LocalePlugin', 'primitiveLanguage', [space.w_nil])
+        external_call(space, 'LocalePlugin', 'primitiveLanguage', [space.w_nil])
 
 def test_locale_plugin_primLang(monkeypatch):
     from rpython.rlib import rlocale
     def setlocale(*args):
         return "en_US.UTF-8"
     monkeypatch.setattr(rlocale, "setlocale", setlocale)
-    w_locale_str = external_call('LocalePlugin', 'primitiveLanguage', [space.w_nil])
+    w_locale_str = external_call(space, 'LocalePlugin', 'primitiveLanguage', [space.w_nil])
     assert space.unwrap_string(w_locale_str) == "en"
 
 def test_locale_plugin_primCountry_fails(monkeypatch):
@@ -399,44 +368,44 @@ def test_locale_plugin_primCountry_fails(monkeypatch):
         return "C"
     monkeypatch.setattr(rlocale, "setlocale", setlocale)
     with py.test.raises(PrimitiveFailedError):
-        external_call('LocalePlugin', 'primitiveCountry', [space.w_nil])
+        external_call(space, 'LocalePlugin', 'primitiveCountry', [space.w_nil])
 
 def test_locale_plugin_primCountry(monkeypatch):
     from rpython.rlib import rlocale
     def setlocale(*args):
         return "en_US.UTF-8"
     monkeypatch.setattr(rlocale, "setlocale", setlocale)
-    w_locale_str = external_call('LocalePlugin', 'primitiveCountry', [space.w_nil])
+    w_locale_str = external_call(space, 'LocalePlugin', 'primitiveCountry', [space.w_nil])
     assert space.unwrap_string(w_locale_str) == "US"
 
-def test_misc_primitiveIndexOfAscciiInString(monkeypatch):
+def test_misc_primitiveIndexOfAsciiInString(monkeypatch):
     assert space.unwrap_int(
-        external_call(
+        external_call(space,
             'MiscPrimitivePlugin',
             'primitiveIndexOfAsciiInString',
             [space.w_nil, space.wrap_char("f"), space.w("foo"), space.w(1)])) == 1
     assert space.unwrap_int(
-        external_call(
+        external_call(space,
             'MiscPrimitivePlugin',
             'primitiveIndexOfAsciiInString',
             [space.w_nil, space.wrap_char("o"), space.w("foo"), space.w(1)])) == 2
     assert space.unwrap_int(
-        external_call(
+        external_call(space,
             'MiscPrimitivePlugin',
             'primitiveIndexOfAsciiInString',
             [space.w_nil, space.wrap_char("f"), space.w("foo"), space.w(2)])) == 0
     assert space.unwrap_int(
-        external_call(
+        external_call(space,
             'MiscPrimitivePlugin',
             'primitiveIndexOfAsciiInString',
             [space.w_nil, space.wrap_char("f"), space.w("foo"), space.w(100)])) == 0
     with py.test.raises(PrimitiveFailedError):
-        external_call(
+        external_call(space,
             'MiscPrimitivePlugin',
             'primitiveIndexOfAsciiInString',
             [space.w_nil, space.wrap_char("f"), space.w("foo"), space.w(0)])
     with py.test.raises(PrimitiveFailedError):
-        external_call(
+        external_call(space,
             'MiscPrimitivePlugin',
             'primitiveIndexOfAsciiInString',
             [space.w_nil, space.wrap_char("f"), space.w("foo"), space.w(-1)])

--- a/rsqueakvm/test/test_external_calls.py
+++ b/rsqueakvm/test/test_external_calls.py
@@ -32,7 +32,10 @@ def test_fileplugin_filedelete(monkeypatch):
     monkeypatch.setattr(os, "remove", remove)
     try:
         stack = [space.w(1), space.wrap_string("myFile")]
-        w_c = external_call(space, 'FilePlugin', 'primitiveFileDelete', stack)
+        w_c = external_call(space,
+            'FilePlugin',
+            'primitiveFileDelete',
+            stack)
     finally:
         monkeypatch.undo()
 
@@ -44,7 +47,10 @@ def test_fileplugin_filedelete_raises(monkeypatch):
     try:
         with py.test.raises(PrimitiveFailedError):
             stack = [space.w(1), space.wrap_string("myFile")]
-            w_c = external_call(space, 'FilePlugin', 'primitiveFileDelete', stack)
+            w_c = external_call(space,
+                'FilePlugin',
+                'primitiveFileDelete',
+                stack)
     finally:
         monkeypatch.undo()
 
@@ -56,7 +62,10 @@ def test_fileplugin_dircreate(monkeypatch):
     monkeypatch.setattr(os, "mkdir", mkdir)
     try:
         stack = [space.w(1), space.wrap_string("myPrimDir")]
-        w_c = external_call(space, 'FilePlugin', 'primitiveDirectoryCreate', stack)
+        w_c = external_call(space,
+            'FilePlugin',
+            'primitiveDirectoryCreate',
+            stack)
     finally:
         monkeypatch.undo()
 
@@ -68,7 +77,10 @@ def test_fileplugin_dircreate_raises(monkeypatch):
     try:
         with py.test.raises(PrimitiveFailedError):
             stack = [space.w(1), space.wrap_string("myPrimDir")]
-            w_c = external_call(space, 'FilePlugin', 'primitiveDirectoryCreate', stack)
+            w_c = external_call(space,
+                'FilePlugin',
+                'primitiveDirectoryCreate',
+                stack)
     finally:
         monkeypatch.undo()
 
@@ -80,7 +92,10 @@ def test_fileplugin_dirdelete(monkeypatch):
     monkeypatch.setattr(os, "rmdir", rmdir)
     try:
         stack = [space.w(1), space.wrap_string("myPrimDir")]
-        w_c = external_call(space, 'FilePlugin', 'primitiveDirectoryDelete', stack)
+        w_c = external_call(space,
+            'FilePlugin',
+            'primitiveDirectoryDelete',
+            stack)
     finally:
         monkeypatch.undo()
 
@@ -95,7 +110,10 @@ def test_fileplugin_filewrite_bytes(monkeypatch):
     content.bytes = ["a", "b", "c", "d"]
     try:
         stack = [space.w(1), space.w(1), content, space.w(1), space.w(4)]
-        w_c = external_call(space, 'FilePlugin', 'primitiveFileWrite', stack)
+        w_c = external_call(space,
+            'FilePlugin',
+            'primitiveFileWrite',
+            stack)
     finally:
         monkeypatch.undo()
 
@@ -110,7 +128,10 @@ def test_fileplugin_filewrite_words(monkeypatch):
     content.words = [rffi.r_uint(1633837924)]
     try:
         stack = [space.w(1), space.w(1), content, space.w(1), space.w(1)]
-        w_c = external_call(space, 'FilePlugin', 'primitiveFileWrite', stack)
+        w_c = external_call(space,
+            'FilePlugin',
+            'primitiveFileWrite',
+            stack)
     finally:
         monkeypatch.undo()
 
@@ -125,7 +146,10 @@ def test_fileplugin_filewrite_float(monkeypatch):
 
     try:
         stack = [space.w(1), space.w(1), content, space.w(1), space.w(1)]
-        w_c = external_call(space, 'FilePlugin', 'primitiveFileWrite', stack)
+        w_c = external_call(space,
+            'FilePlugin',
+            'primitiveFileWrite',
+            stack)
     finally:
         monkeypatch.undo()
 
@@ -139,13 +163,19 @@ def test_fileplugin_filewrite_largeposint(monkeypatch):
     content = W_LargeIntegerWord(space, space.w_LargePositiveInteger, r_uint(1633837924), 4)
     try:
         stack = [space.w(1), space.w(1), content, space.w(1), space.w(4)]
-        w_c = external_call(space, 'FilePlugin', 'primitiveFileWrite', stack)
+        w_c = external_call(space,
+            'FilePlugin',
+            'primitiveFileWrite',
+            stack)
     finally:
         monkeypatch.undo()
 
 def test_fileplugin_filewrite_pointers(monkeypatch):
     with py.test.raises(PrimitiveFailedError):
-        external_call(space, 'FilePlugin', 'primitiveFileWrite', [1, 1, None, 1, 1])
+        external_call(space,
+            'FilePlugin',
+            'primitiveFileWrite',
+            [1, 1, None, 1, 1])
 
 def test_fileplugin_filewrite_bitmap(monkeypatch):
     def write(fd, data):
@@ -158,7 +188,10 @@ def test_fileplugin_filewrite_bitmap(monkeypatch):
     content._real_depth_buffer[0] = rffi.r_uint(1633837924)
     try:
         stack = [space.w(1), space.w(1), content, space.w(1), space.w(1)]
-        w_c = external_call(space, 'FilePlugin', 'primitiveFileWrite', stack)
+        w_c = external_call(space,
+            'FilePlugin',
+            'primitiveFileWrite',
+            stack)
     finally:
         monkeypatch.undo()
 
@@ -170,19 +203,28 @@ def test_fileplugin_dirdelete_raises(monkeypatch):
     try:
         with py.test.raises(PrimitiveFailedError):
             stack = [space.w(1), space.wrap_string("myPrimDir")]
-            w_c = external_call(space, 'FilePlugin', 'primitiveDirectoryDelete', stack)
+            w_c = external_call(space,
+                'FilePlugin',
+                'primitiveDirectoryDelete',
+                stack)
     finally:
         monkeypatch.undo()
 
 def test_fileplugin_stdio_handles():
-    handles = space.unwrap_array(external_call(space, 'FilePlugin', 'primitiveFileStdioHandles', [None]))
+    handles = space.unwrap_array(external_call(space,
+        'FilePlugin',
+        'primitiveFileStdioHandles',
+        [None]))
     assert handles[0].value == 0
     assert handles[1].value == 1
     assert handles[2].value == 2
 
 def test_fileplugin_path_sep():
     import os
-    sep = chr(external_call(space, 'FilePlugin', 'primitiveDirectoryDelimitor', [None]).value)
+    sep = chr(external_call(space,
+        'FilePlugin',
+        'primitiveDirectoryDelimitor',
+        [None]).value)
     assert sep == os.path.sep
 
 def test_fileplugin_dir_lookup(monkeypatch):
@@ -205,16 +247,25 @@ def test_fileplugin_dir_lookup(monkeypatch):
     monkeypatch.setattr(os, "stat", stat)
     try:
         result = space.unwrap_array(
-            external_call(space, "FilePlugin", "primitiveDirectoryLookup", [None, '', 1]))
+            external_call(space,
+                'FilePlugin',
+                'primitiveDirectoryLookup',
+                [None, '', 1]))
         assert result[0].unwrap_string(space) == "foo"
         assert result[1].unwrap_long_untranslated(space) > realstat.st_ctime
         assert result[2].unwrap_long_untranslated(space) > realstat.st_mtime
         assert result[3] is space.w_false
         assert result[4].unwrap_long_untranslated(space) == realstat.st_size
         with py.test.raises(PrimitiveFailedError):
-            external_call(space, "FilePlugin", "primitiveDirectoryLookup", [None, '/rsqueaktest/', 4])
+            external_call(space,
+                'FilePlugin',
+                'primitiveDirectoryLookup',
+                [None, '/rsqueaktest/', 4])
         with py.test.raises(PrimitiveFailedError):
-            external_call(space, "FilePlugin", "primitiveDirectoryLookup", [None, '/rsqueaktest/', 2])
+            external_call(space,
+                'FilePlugin',
+                'primitiveDirectoryLookup',
+                [None, '/rsqueaktest/', 2])
     finally:
         monkeypatch.undo()
 
@@ -233,17 +284,34 @@ def test_fileplugin_file_open(monkeypatch):
     monkeypatch.setattr(os, "open", open)
     try:
         required_mode = os.O_RDWR | os.O_CREAT
-        assert external_call(space, "FilePlugin", "primitiveFileOpen", [None, "new_file", True]).value == 32
+        assert external_call(space,
+            'FilePlugin',
+            'primitiveFileOpen',
+            [None, "new_file", True]).value == 32
         required_mode = os.O_RDWR
-        assert external_call(space, "FilePlugin", "primitiveFileOpen", [None, __file__, True]).value == 32
+        assert external_call(space,
+            'FilePlugin',
+            'primitiveFileOpen',
+            [None, __file__, True]).value == 32
         required_mode = os.O_RDONLY
-        assert external_call(space, "FilePlugin", "primitiveFileOpen", [None, __file__, False]).value == 32
+        assert external_call(space,
+            'FilePlugin',
+            'primitiveFileOpen',
+            [None, __file__, False]).value == 32
         required_mode = os.O_RDONLY
-        assert external_call(space, "FilePlugin", "primitiveFileOpen", [None, __file__, False]).value == 32
-        assert external_call(space, "FilePlugin", "primitiveFileOpen", [None, "new_file", False]) is space.w_nil
+        assert external_call(space,
+            'FilePlugin',
+            'primitiveFileOpen',
+            [None, __file__, False]).value == 32
+        assert external_call(space,
+            'FilePlugin',
+            'primitiveFileOpen',
+            [None, "new_file", False]) is space.w_nil
         with py.test.raises(PrimitiveFailedError):
-            external_call(space, "FilePlugin", "primitiveDirectoryLookup",
-                          [None, os.path.dirname(__file__), True])
+            external_call(space,
+                'FilePlugin',
+                'primitiveDirectoryLookup',
+                [None, os.path.dirname(__file__), True])
     finally:
         monkeypatch.undo()
 
@@ -252,32 +320,47 @@ def test_fileplugin_file_close(monkeypatch):
     def dontclose(fd): raise OSError
     try:
         monkeypatch.setattr(os, "close", doclose)
-        assert external_call(space, "FilePlugin", "primitiveFileClose", [None, 32]) is space.w_nil
+        assert external_call(space,
+            'FilePlugin',
+            'primitiveFileClose',
+            [None, 32]) is space.w_nil
         monkeypatch.setattr(os, "close", dontclose)
         with py.test.raises(PrimitiveFailedError):
-            external_call(space, "FilePlugin", "primitiveFileClose", [None, 32])
+            external_call(space,
+                'FilePlugin',
+                'primitiveFileClose',
+                [None, 32])
     finally:
         monkeypatch.undo()
 
 def test_fileplugin_file_atend(monkeypatch):
     fd = os.open(__file__, os.O_RDONLY)
     try:
-        assert external_call(space, "FilePlugin", "primitiveFileAtEnd", [None, fd]) is space.w_false
+        assert external_call(space,
+            'FilePlugin',
+            'primitiveFileAtEnd',
+            [None, fd]) is space.w_false
         os.lseek(fd, 0, os.SEEK_END)
-        assert external_call(space, "FilePlugin", "primitiveFileAtEnd", [None, fd]) is space.w_true
+        assert external_call(space,
+            'FilePlugin',
+            'primitiveFileAtEnd',
+            [None, fd]) is space.w_true
     finally:
         os.close(fd)
 
 def test_fileplugin_file_read(monkeypatch):
     with py.test.raises(PrimitiveFailedError):
-        external_call(space, "FilePlugin", "primitiveFileRead", [None, 32, None, 1, 12])
+        external_call(space, 'FilePlugin', 'primitiveFileRead', [None, 32, None, 1, 12])
 
     def raiseread(fd, count):
         raise OSError
     monkeypatch.setattr(os, "read", raiseread)
     try:
         with py.test.raises(PrimitiveFailedError):
-            external_call(space, "FilePlugin", "primitiveFileRead", [None, 32, "hello", 1, 5])
+            external_call(space,
+                'FilePlugin',
+                'primitiveFileRead',
+                [None, 32, "hello", 1, 5])
     finally:
         monkeypatch.undo()
 
@@ -287,16 +370,28 @@ def test_fileplugin_file_read(monkeypatch):
     monkeypatch.setattr(os, "read", read)
     try:
         with py.test.raises(PrimitiveFailedError):
-            external_call(space, "FilePlugin", "primitiveFileRead", [None, 32, "123", 1, 5])
+            external_call(space,
+                'FilePlugin',
+                'primitiveFileRead',
+                [None, 32, "123", 1, 5])
         with py.test.raises(PrimitiveFailedError):
-            external_call(space, "FilePlugin", "primitiveFileRead", [None, 32, "12345", 2, 5])
+            external_call(space,
+                'FilePlugin',
+                'primitiveFileRead',
+                [None, 32, "12345", 2, 5])
 
         w_out = space.w("123456")
-        assert external_call(space, "FilePlugin", "primitiveFileRead", [None, 32, w_out, 1, 5]).value == 5
+        assert external_call(space,
+            'FilePlugin',
+            'primitiveFileRead',
+            [None, 32, w_out, 1, 5]).value == 5
         assert w_out.unwrap_string(space) == "hello6"
 
         w_out = space.w("123456")
-        assert external_call(space, "FilePlugin", "primitiveFileRead", [None, 32, w_out, 2, 5]).value == 5
+        assert external_call(space,
+            'FilePlugin',
+            'primitiveFileRead',
+            [None, 32, w_out, 2, 5]).value == 5
         assert w_out.unwrap_string(space) == "1hello"
     finally:
         monkeypatch.undo()
@@ -305,10 +400,19 @@ def test_fileplugin_file_get_position(monkeypatch):
     fd = os.open(__file__, os.O_RDONLY)
     try:
         with py.test.raises(PrimitiveFailedError):
-            external_call(space, "FilePlugin", "primitiveFileGetPosition", [None, -1])
-        assert external_call(space, "FilePlugin", "primitiveFileGetPosition", [None, fd]).value == 0
+            external_call(space,
+                'FilePlugin',
+                'primitiveFileGetPosition',
+                [None, -1])
+        assert external_call(space,
+            'FilePlugin',
+            'primitiveFileGetPosition',
+            [None, fd]).value == 0
         os.lseek(fd, 32, os.SEEK_CUR)
-        assert external_call(space, "FilePlugin", "primitiveFileGetPosition", [None, fd]).value == 32
+        assert external_call(space,
+            'FilePlugin',
+            'primitiveFileGetPosition',
+            [None, fd]).value == 32
     finally:
         os.close(fd)
 
@@ -316,8 +420,14 @@ def test_fileplugin_file_set_position(monkeypatch):
     fd = os.open(__file__, os.O_RDONLY)
     try:
         with py.test.raises(PrimitiveFailedError):
-            external_call(space, "FilePlugin", "primitiveFileSetPosition", [None, -1, 32])
-        external_call(space, "FilePlugin", "primitiveFileSetPosition", [None, fd, 32])
+            external_call(space,
+                'FilePlugin',
+                'primitiveFileSetPosition',
+                [None, -1, 32])
+        external_call(space,
+            'FilePlugin',
+            'primitiveFileSetPosition',
+            [None, fd, 32])
         assert os.lseek(fd, 0, os.SEEK_CUR) == 32
     finally:
         os.close(fd)
@@ -326,8 +436,14 @@ def test_fileplugin_file_size(monkeypatch):
     fd = os.open(__file__, os.O_RDONLY)
     try:
         with py.test.raises(PrimitiveFailedError):
-            external_call(space, "FilePlugin", "primitiveFileSize", [None, -1])
-        assert external_call(space, "FilePlugin", "primitiveFileSize", [None, fd]).value == os.fstat(fd).st_size
+            external_call(space,
+                'FilePlugin',
+                'primitiveFileSize',
+                [None, -1])
+        assert external_call(space,
+            'FilePlugin',
+            'primitiveFileSize',
+            [None, fd]).value == os.fstat(fd).st_size
     finally:
         os.close(fd)
 
@@ -339,10 +455,16 @@ def test_fileplugin_file_truncate(monkeypatch):
     def failtrunc(fd, p): raise OSError
     monkeypatch.setattr(file_plugin, "ftruncate", truncate)
     try:
-        external_call(space, "FilePlugin", "primitiveFileTruncate", [None, 32, 12])
+        external_call(space,
+            'FilePlugin',
+            'primitiveFileTruncate',
+            [None, 32, 12])
         monkeypatch.setattr(file_plugin, "ftruncate", failtrunc)
         with py.test.raises(PrimitiveFailedError):
-            external_call(space, "FilePlugin", "primitiveFileTruncate", [None, 32, 12])
+            external_call(space,
+                'FilePlugin',
+                'primitiveFileTruncate',
+                [None, 32, 12])
     finally:
         monkeypatch.undo()
 
@@ -352,14 +474,20 @@ def test_locale_plugin_primLang_fails(monkeypatch):
         return "C"
     monkeypatch.setattr(rlocale, "setlocale", setlocale)
     with py.test.raises(PrimitiveFailedError):
-        external_call(space, 'LocalePlugin', 'primitiveLanguage', [space.w_nil])
+        external_call(space,
+            'LocalePlugin',
+            'primitiveLanguage',
+            [space.w_nil])
 
 def test_locale_plugin_primLang(monkeypatch):
     from rpython.rlib import rlocale
     def setlocale(*args):
         return "en_US.UTF-8"
     monkeypatch.setattr(rlocale, "setlocale", setlocale)
-    w_locale_str = external_call(space, 'LocalePlugin', 'primitiveLanguage', [space.w_nil])
+    w_locale_str = external_call(space,
+        'LocalePlugin',
+        'primitiveLanguage',
+        [space.w_nil])
     assert space.unwrap_string(w_locale_str) == "en"
 
 def test_locale_plugin_primCountry_fails(monkeypatch):
@@ -368,14 +496,20 @@ def test_locale_plugin_primCountry_fails(monkeypatch):
         return "C"
     monkeypatch.setattr(rlocale, "setlocale", setlocale)
     with py.test.raises(PrimitiveFailedError):
-        external_call(space, 'LocalePlugin', 'primitiveCountry', [space.w_nil])
+        external_call(space,
+            'LocalePlugin',
+            'primitiveCountry',
+            [space.w_nil])
 
 def test_locale_plugin_primCountry(monkeypatch):
     from rpython.rlib import rlocale
     def setlocale(*args):
         return "en_US.UTF-8"
     monkeypatch.setattr(rlocale, "setlocale", setlocale)
-    w_locale_str = external_call(space, 'LocalePlugin', 'primitiveCountry', [space.w_nil])
+    w_locale_str = external_call(space,
+        'LocalePlugin',
+        'primitiveCountry',
+        [space.w_nil])
     assert space.unwrap_string(w_locale_str) == "US"
 
 def test_misc_primitiveIndexOfAsciiInString(monkeypatch):

--- a/rsqueakvm/test/test_immutability_plugin.py
+++ b/rsqueakvm/test/test_immutability_plugin.py
@@ -40,6 +40,9 @@ def test_W_Immutable_BytesObject():
     assert w_ibytes.getchar(3) == '\x00'
     w_ibytes.setchar(3, '\xAA')
     assert w_ibytes.getchar(3) == '\x00'
+    assert w_ibytes._version() is None
+    w_ibytes.mutate()
+    assert w_ibytes._version() is None
     py.test.raises(IndexError, lambda: w_ibytes.getchar(20))
 
 

--- a/rsqueakvm/test/test_immutability_plugin.py
+++ b/rsqueakvm/test/test_immutability_plugin.py
@@ -2,6 +2,7 @@ import py
 import pytest
 
 from rsqueakvm import storage_classes
+from rsqueakvm.error import PrimitiveFailedError
 from rsqueakvm.plugins.immutability.bytes import W_Immutable_BytesObject
 from rsqueakvm.plugins.immutability.pointers import (
     select_immutable_pointers_class)
@@ -74,7 +75,67 @@ def test_W_Immutable_WordsObject():
     py.test.raises(AssertionError, lambda: w_iwords.getword(20))
 
 def test_primIsImmutable():
+    w_class = bootstrap_class(0, format=storage_classes.WORDS)
+    w_words = w_class.as_class_get_shadow(space).new(20)
+    w_iwords = W_Immutable_WordsObject(space, w_class, w_words.words)
     assert external_call(space,
         'ImmutabilityPlugin',
         'primitiveIsImmutable',
-        [space.w("foo")]) == space.w_false
+        [w_words]) == space.w_false
+    assert external_call(space,
+        'ImmutabilityPlugin',
+        'primitiveIsImmutable',
+        [w_iwords]) == space.w_true
+
+def test_primImmutableFrom_bytes():
+    w_bytes_cls = bootstrap_class(0, format=storage_classes.BYTES)
+    w_bytes_obj = w_bytes_cls.as_class_get_shadow(space).new(20)
+    w_ibytes_obj = external_call(space,
+        'ImmutabilityPlugin',
+        'primitiveImmutableFrom',
+        [w_bytes_cls, w_bytes_obj])
+    assert w_ibytes_obj.is_immutable()
+    assert w_ibytes_obj.getclass(space).is_same_object(w_bytes_cls)
+    assert w_ibytes_obj.size() == 20
+    assert w_ibytes_obj.getchar(3) == '\x00'
+    w_ibytes_obj.setchar(3, '\xAA')
+    assert w_ibytes_obj.getchar(3) == '\x00'
+
+def test_primImmutableFrom_pointers():
+    size = 10
+    w_pointers_cls = bootstrap_class(0)
+    w_pointers_obj = W_PointersObject(space, w_pointers_cls, size)
+    w_pointers_obj.store(space, 0, space.w_true)
+    w_ipointers_obj = external_call(space,
+        'ImmutabilityPlugin',
+        'primitiveImmutableFrom',
+        [w_pointers_cls, w_pointers_obj])
+    assert w_ipointers_obj.is_immutable()
+    assert w_ipointers_obj.getclass(space).is_same_object(w_pointers_cls)
+    assert w_ipointers_obj.size() == size
+    assert w_ipointers_obj.fetch(space, 0) is space.w_true;
+    w_ipointers_obj.store(space, 0, space.w_false)
+    assert w_ipointers_obj.fetch(space, 0) is space.w_true;
+
+def test_primImmutableFrom_words():
+    w_words_cls = bootstrap_class(0, format=storage_classes.WORDS)
+    w_words_obj = w_words_cls.as_class_get_shadow(space).new(20)
+    w_iwords_obj = external_call(space,
+        'ImmutabilityPlugin',
+        'primitiveImmutableFrom',
+        [w_words_cls, w_words_obj])
+    assert w_iwords_obj.is_immutable()
+    assert w_iwords_obj.getclass(space).is_same_object(w_words_cls)
+    assert w_iwords_obj.size() == 20
+    assert w_iwords_obj.getword(3) == 0
+    w_iwords_obj.setword(3, 42)
+    assert w_iwords_obj.getword(3) == 0
+
+def test_primImmutableFrom_float():
+    w_float_cls = bootstrap_class(0, format=storage_classes.FLOAT)
+    w_float_obj = w_float_cls.as_class_get_shadow(space).new(20)
+    with py.test.raises(PrimitiveFailedError):
+        external_call(space,
+            'ImmutabilityPlugin',
+            'primitiveImmutableFrom',
+            [w_float_cls, w_float_obj])

--- a/rsqueakvm/test/test_immutability_plugin.py
+++ b/rsqueakvm/test/test_immutability_plugin.py
@@ -140,6 +140,56 @@ def test_primImmutableFrom_float():
             'primitiveImmutableFrom',
             [w_float_cls, w_float_obj])
 
-def test_primImmutableFromArgs():
-    # stub
-    assert space.w_true == space.w_true
+def test_primImmutableFromArgs_bytes():
+    placeholder1 = space.w(1)
+    placeholder2 = space.w(2)
+    w_bytes_cls = bootstrap_class(0, format=storage_classes.BYTES)
+    w_ibytes_obj = external_call(space,
+        'ImmutabilityPlugin',
+        'primitiveImmutableFromArgs',
+        [w_bytes_cls, placeholder1, placeholder2])
+    assert w_ibytes_obj.is_immutable();
+    assert w_ibytes_obj.getclass(space).is_same_object(w_bytes_cls)
+    assert w_ibytes_obj.getchar(0) == '\x01'
+    assert w_ibytes_obj.getchar(1) == '\x02'
+    w_ibytes_obj.setchar(0, placeholder2)
+    assert w_ibytes_obj.getchar(0) == '\x01'
+
+def test_primImmutableFromArgs_pointers():
+    placeholder1 = space.w(1)
+    placeholder2 = space.w(2)
+    w_pointers_cls = bootstrap_class(0)
+    w_ipointers_obj = external_call(space,
+        'ImmutabilityPlugin',
+        'primitiveImmutableFromArgs',
+        [w_pointers_cls, placeholder1, placeholder2])
+    assert w_ipointers_obj.is_immutable();
+    assert w_ipointers_obj.getclass(space).is_same_object(w_pointers_cls)
+    assert w_ipointers_obj.fetch(space, 0) is placeholder1
+    assert w_ipointers_obj.fetch(space, 1) is placeholder2
+    w_ipointers_obj.store(space, 0, placeholder2)
+    assert w_ipointers_obj.fetch(space, 0) is placeholder1
+
+def test_primImmutableFromArgs_words():
+    placeholder1 = space.w(1)
+    placeholder2 = space.w(2)
+    w_words_cls = bootstrap_class(0, format=storage_classes.WORDS)
+    w_iwords_obj = external_call(space,
+        'ImmutabilityPlugin',
+        'primitiveImmutableFromArgs',
+        [w_words_cls, placeholder1, placeholder2])
+    assert w_iwords_obj.is_immutable();
+    assert w_iwords_obj.getclass(space).is_same_object(w_words_cls)
+    assert w_iwords_obj.getword(0) == 1
+    assert w_iwords_obj.getword(1) == 2
+    w_iwords_obj.setword(0, placeholder2)
+    assert w_iwords_obj.getword(0) == 1
+
+def test_primImmutableFromArgs_float():
+    w_float_cls = bootstrap_class(0, format=storage_classes.FLOAT)
+    w_float_obj = w_float_cls.as_class_get_shadow(space).new(20)
+    with py.test.raises(PrimitiveFailedError):
+        external_call(space,
+            'ImmutabilityPlugin',
+            'primitiveImmutableFromArgs',
+            [w_float_cls, space.w(1)])

--- a/rsqueakvm/test/test_immutability_plugin.py
+++ b/rsqueakvm/test/test_immutability_plugin.py
@@ -196,3 +196,25 @@ def test_primImmutableFromArgs_float():
             'ImmutabilityPlugin',
             'primitiveImmutableFromArgs',
             [w_float_cls, space.w(1)])
+
+def test_primImmutableFromArgs_no_args():
+    w_pointers_cls = bootstrap_class(0)
+    with py.test.raises(PrimitiveFailedError):
+        external_call(space,
+            'ImmutabilityPlugin',
+            'primitiveImmutableFromArgs',
+            [w_pointers_cls])
+
+def test_primImmutableFromArgs_mismatch():
+    w_bytes_cls = bootstrap_class(0, format=storage_classes.BYTES)
+    w_words_cls = bootstrap_class(0, format=storage_classes.WORDS)
+    with py.test.raises(PrimitiveFailedError):
+        external_call(space,
+            'ImmutabilityPlugin',
+            'primitiveImmutableFromArgs',
+            [w_bytes_cls, space.w("foo")])
+    with py.test.raises(PrimitiveFailedError):
+        external_call(space,
+            'ImmutabilityPlugin',
+            'primitiveImmutableFromArgs',
+            [w_words_cls, space.w("foo")])

--- a/rsqueakvm/test/test_immutability_plugin.py
+++ b/rsqueakvm/test/test_immutability_plugin.py
@@ -8,7 +8,7 @@ from rsqueakvm.plugins.immutability.pointers import (
 from rsqueakvm.plugins.immutability.words import W_Immutable_WordsObject
 from rsqueakvm.model.pointers import W_PointersObject
 
-from .util import create_space, cleanup_module
+from .util import create_space, cleanup_module, external_call
 
 
 def test_space():
@@ -72,3 +72,9 @@ def test_W_Immutable_WordsObject():
     w_iwords.setword(3, 42)
     assert w_iwords.getword(3) == 0
     py.test.raises(AssertionError, lambda: w_iwords.getword(20))
+
+def test_primIsImmutable():
+    assert external_call(space,
+        'ImmutabilityPlugin',
+        'primitiveIsImmutable',
+        [space.w("foo")]) == space.w_false

--- a/rsqueakvm/test/test_immutability_plugin.py
+++ b/rsqueakvm/test/test_immutability_plugin.py
@@ -139,3 +139,7 @@ def test_primImmutableFrom_float():
             'ImmutabilityPlugin',
             'primitiveImmutableFrom',
             [w_float_cls, w_float_obj])
+
+def test_primImmutableFromArgs():
+    # stub
+    assert space.w_true == space.w_true

--- a/rsqueakvm/test/util.py
+++ b/rsqueakvm/test/util.py
@@ -20,26 +20,30 @@ def mock(space, stack, context = None):
     for i in range(len(stack)):
         frame.as_context_get_shadow(space).push(stack[i])
     interp = InterpreterForTest(space)
-    interp.space.set_system_attribute(constants.SYSTEM_ATTRIBUTE_IMAGE_NAME_INDEX, IMAGENAME)
+    interp.space.set_system_attribute(
+        constants.SYSTEM_ATTRIBUTE_IMAGE_NAME_INDEX,
+        IMAGENAME)
     return interp, frame, len(stack)
 
 def _prim(space, code, stack, context = None):
     interp, w_frame, argument_count = mock(space, stack, context)
-    prim_table[code](interp, w_frame.as_context_get_shadow(space), argument_count-1, context and context.as_context_get_shadow(space).w_method())
+    prim_table[code](interp,
+                     w_frame.as_context_get_shadow(space),
+                     argument_count-1,
+                     context and context.as_context_get_shadow(space).w_method())
     res = w_frame.as_context_get_shadow(space).pop()
     s_frame = w_frame.as_context_get_shadow(space)
-    assert not s_frame.stackdepth() - s_frame.tempsize()  # check args are consumed
+    assert not s_frame.stackdepth()-s_frame.tempsize() # check args are consumed
     return res
-
-def prim(code, stack, context = None):
-    return _prim(space, code, stack, context)
 
 def external_call(space, module_name, method_name, stack):
     stack = [space.w(o) for o in stack]
     w_description = W_PointersObject(space, space.w_Array, 2)
     w_description.atput0(space, 0, space.w(module_name))
     w_description.atput0(space, 1, space.w(method_name))
-    context = space.make_frame("<not called>", [w_description], stack[0], stack[1:])[0]
+    context = space.make_frame("<not called>",
+                               [w_description],
+                               stack[0], stack[1:])[0]
     return _prim(space, EXTERNAL_CALL, stack, context)
 
 


### PR DESCRIPTION
Add tests for immutable object plug-in primitives.
Also, move `external_call` from `test_external_calls.py` to `utils.py`.