### PR TITLE
@not_rpython instead of """NOT RPYTHON"""

### DIFF
--- a/rsqueakvm/model/compiled_methods.py
+++ b/rsqueakvm/model/compiled_methods.py
@@ -3,7 +3,7 @@ from rsqueakvm.model.base import W_Object, W_AbstractObjectWithIdentityHash
 from rsqueakvm.model.pointers import W_PointersObject
 
 from rpython.rlib import jit
-from rpython.rlib.objectmodel import import_from_mixin, we_are_translated
+from rpython.rlib.objectmodel import not_rpython, we_are_translated
 
 
 class CompiledMethodHeader(object):
@@ -129,8 +129,8 @@ class W_CompiledMethod(W_AbstractObjectWithIdentityHash):
         if index == len(self.literals):
             self.compiledin_class = None
 
+    @not_rpython # Only for testing, not safe.
     def setliterals(self, literals):
-        """NOT RPYTHON""" # Only for testing, not safe.
         self.literals = literals
         self.compiledin_class = None
 

--- a/rsqueakvm/model/numeric.py
+++ b/rsqueakvm/model/numeric.py
@@ -6,7 +6,7 @@ from rsqueakvm.model.base import W_Object, W_AbstractObjectWithIdentityHash, W_A
 from rpython.rlib import longlong2float, jit
 from rpython.rlib.rarithmetic import intmask, r_uint32, r_uint, ovfcheck, r_int64, r_ulonglong
 from rpython.rlib.rstruct.ieee import float_unpack, float_pack
-from rpython.rlib.objectmodel import compute_hash, specialize
+from rpython.rlib.objectmodel import compute_hash, not_rpython
 from rpython.rlib import rbigint
 from rpython.rlib.rerased import new_static_erasing_pair
 
@@ -277,8 +277,8 @@ class W_LargeIntegerBig(W_LargeInteger):
     def unwrap_rbigint(self, space):
         return self.value
 
+    @not_rpython
     def unwrap_long_untranslated(self, space):
-        "NOT RPYTHON"
         return self.value.tolong()
 
     def unwrap_float(self, space):
@@ -370,8 +370,8 @@ class W_LargeIntegerWord(W_LargeInteger):
         else:
             return rbig
 
+    @not_rpython
     def unwrap_long_untranslated(self, space):
-        "NOT RPYTHON"
         if self.is_positive(space):
             return long(self.value)
         else:
@@ -435,8 +435,8 @@ class W_SmallInteger(W_Object):
     def unwrap_rbigint(self, space):
         return rbigint.rbigint.fromint(self.value)
 
+    @not_rpython
     def unwrap_long_untranslated(self, space):
-        "NOT RPYTHON"
         return self.value
 
     def unwrap_float(self, space):

--- a/rsqueakvm/model/variable.py
+++ b/rsqueakvm/model/variable.py
@@ -3,6 +3,7 @@ from rsqueakvm.model.base import W_AbstractObjectWithClassReference
 from rsqueakvm.util.version import Version, elidable_for_version_iff
 
 from rpython.rlib import jit
+from rpython.rlib.objectmodel import not_rpython
 from rpython.rlib.rarithmetic import intmask, r_uint, r_uint32, r_int64
 
 
@@ -140,8 +141,8 @@ class W_BytesObject(W_AbstractObjectWithClassReference):
         else:
             raise error.UnwrappingError
 
+    @not_rpython
     def unwrap_long_untranslated(self, space):
-        "NOT RPYTHON"
         return self.unwrap_rbigint(space).tolong()
 
     @elidable_for_version_iff(0, cond=lambda self: jit.isconstant(self))

--- a/rsqueakvm/plugins/plugin.py
+++ b/rsqueakvm/plugins/plugin.py
@@ -1,4 +1,5 @@
 from rpython.rlib import jit
+from rpython.rlib.objectmodel import not_rpython
 
 from rsqueakvm import error
 
@@ -27,8 +28,8 @@ class Plugin(object):
     def _find_prim(self, name):
         return self.primitives.get(name, None)
 
+    @not_rpython
     def expose_primitive(self,  wrap_func=None, **kwargs):
-        """NOT RPYTHON"""
         from rsqueakvm.primitives import wrap_primitive, unwrap_alternatives
         if not wrap_func:
             if kwargs.get('unwrap_specs', None):

--- a/rsqueakvm/plugins/socket_plugin.py
+++ b/rsqueakvm/plugins/socket_plugin.py
@@ -48,8 +48,8 @@ class SocketPluginClass(Plugin):
         self.last_lookup = Cell(None)
 
     # cannot overload call (plugins are PBCs) so we decorate the decorator
+    @objectmodel.not_rpython
     def expose_primitive(self, wrap_func=None, **kwargs):
-        """NOT RPYTHON"""
         original_decorator = Plugin.expose_primitive(self, wrap_func=wrap_func, **kwargs)
         def decorator(func):
             original_decorator(func)

--- a/rsqueakvm/squeakimage.py
+++ b/rsqueakvm/squeakimage.py
@@ -957,14 +957,14 @@ class GenericObject(object):
     def get_hash(self):
         return self.chunk.hash
 
+    @objectmodel.not_rpython
     def as_string(self):
-        """NOT RPYTHON"""
         return "".join([chr(c) for bytes in
             [splitter[8,8,8,8](w) for w in self.chunk.data]
             for c in bytes if c != 0])
 
+    @objectmodel.not_rpython
     def classname(self):
-        """NOT RPYTHON"""
         return self.g_class.pointers[6].as_string()
 
 

--- a/rsqueakvm/util/shell.py
+++ b/rsqueakvm/util/shell.py
@@ -48,9 +48,8 @@ def cmd(func):
     autocompletions["!%s" % func.__name__] = None
     return func
 
-
+@objectmodel.not_rpython
 def completer(text, state, completions=None):
-    "NOT RPYTHON"
     if not completions:
         completions = autocompletions
     matches = 0

--- a/rsqueakvm/util/system.py
+++ b/rsqueakvm/util/system.py
@@ -5,7 +5,7 @@ import platform
 from rpython.config.config import OptionDescription, BoolOption, \
     IntOption, StrOption, ArbitraryOption, FloatOption, DEFAULT_OPTION_NAME
 from rpython.config.translationoption import get_combined_translation_config
-
+from rpython.rlib.objectmodel import not_rpython
 
 IS_POSIX = os.name == "posix"
 IS_WINDOWS = os.name == "nt"
@@ -24,8 +24,8 @@ if IS_WINDOWS and (not any(arg.startswith("-Ojit") for arg in sys.argv)):
         return uname
     platform.uname = win32uname
 
+@not_rpython
 def translation_options():
-    """NOT RPYTHON"""
     return OptionDescription(
         "rsqueak", "RSqueak Options", [
             StrOption(
@@ -48,8 +48,8 @@ def translation_options():
         ]
     )
 
+@not_rpython
 def expose_options(config):
-    """NOT RPYTHON"""
     for name in translation_options().getpaths():
         globals()[name] = getattr(config.rsqueak, name)
     globals()["translationconfig"] = config.translation


### PR DESCRIPTION
Use `@not_rpython` decorator instead of `"""NOT RPYTHON"""` doc string (as requested in #144).
Also, remove some unnecessary imports.